### PR TITLE
Avoid NULL character in Crystal.CIFOutput.

### DIFF
--- a/ObjCryst/ObjCryst/Crystal.cpp
+++ b/ObjCryst/ObjCryst/Crystal.cpp
@@ -974,7 +974,7 @@ void Crystal::CIFOutput(ostream &os, double mindist)const
 
    //Symmetry
    os <<"_symmetry_space_group_name_H-M    '"
-      << this->GetSpaceGroup().GetCCTbxSpg().match_tabulated_settings().hermann_mauguin()<<":"<<this->GetSpaceGroup().GetExtension()<<"'"<<endl;
+      << this->GetSpaceGroup().GetName() << "'" << endl;
    os <<"_symmetry_space_group_name_Hall   '"
       << this->GetSpaceGroup().GetCCTbxSpg().match_tabulated_settings().hall()<<"'"<<endl;
    os <<endl;


### PR DESCRIPTION
This code

``` cpp
Crystal fcc(3.523, 3.523, 3.523, 90, 90, 90, "F m -3 m");
fcc.CIFOutput(std::cout);
```

would write a CIF content with NULL byte in the _symmetry_space_group_name_H-M field.
This is because SpaceGroup.GetExtension() is a NULL character.  This patch
seems to fix it, but I am not sure if SpaceGroup.GetName() is guaranteed
to be the H-M symbol.  I found very similar statements in the
[InitSpaceGroup code](https://github.com/vincefn/objcryst/blob/531c1057c5c08800ec7418f291d94b8a769604f2/ObjCryst/ObjCryst/SpaceGroup.cpp#L652) which compute the return value for GetName() and handle a NULL-char  extension.
