### PR TITLE
BUG: add missing header boost/format.hpp.

### DIFF
--- a/ObjCryst/ObjCryst/CIF.cpp
+++ b/ObjCryst/ObjCryst/CIF.cpp
@@ -1,5 +1,6 @@
 #include <ctype.h>
 #include <cmath>
+#include "boost/format.hpp"
 
 #include "cctbx/sgtbx/space_group.h"
 #include "cctbx/sgtbx/space_group_type.h"


### PR DESCRIPTION
Fix compilation error for boost 1.64.  The build passed with older boost-s because of incidental inclusion of boost/format.hpp from other boost headers.