### PR TITLE
Fix warnings from g++ 7.2

### DIFF
--- a/ObjCryst/CrystVector/CrystVector.cpp
+++ b/ObjCryst/CrystVector/CrystVector.cpp
@@ -105,15 +105,15 @@ template<class T> long CrystVector<T>::size()const {return mNumElements;}
 
 template<class T> T CrystVector<T>::sum()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    for(long i=0;i<this->numElements();i++) tmp += *p++ ;
    return tmp;
 }
 template<class T> T CrystVector<T>::min()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -124,8 +124,8 @@ template<class T> T CrystVector<T>::min()const
 }
 template<class T> T CrystVector<T>::max()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -143,8 +143,8 @@ template<class T> unsigned long CrystVector<T>::imin(const unsigned long start0,
       start=0;
       finish=this->numElements();
    }
-   register T tmp=0;
-   register const T *p=this->data()+start;
+   T tmp=0;
+   const T *p=this->data()+start;
    tmp=*p++;
    long im=0;
    for(unsigned long i=start+1;i<finish;i++)
@@ -162,8 +162,8 @@ template<class T> unsigned long CrystVector<T>::imax(const unsigned long start0,
       start=0;
       finish=this->numElements();
    }
-   register T tmp=0;
-   register const T *p=this->data()+start;
+   T tmp=0;
+   const T *p=this->data()+start;
    tmp=*p++;
    long im=start;
    for(unsigned long i=start+1;i<finish;i++)
@@ -199,8 +199,8 @@ template<class T> void CrystVector<T>::resizeAndPreserve(const long newNbElement
 {
    //:TODO: check memory allocation
    if(newNbElements == mNumElements) return;
-   register T * RESTRICT p=mpData;
-   register T * RESTRICT p2,*p1;
+   T * RESTRICT p=mpData;
+   T * RESTRICT p2,*p1;
    mpData=0;
    mpData=new T[newNbElements];
    p2=mpData;
@@ -217,7 +217,7 @@ template<class T> void CrystVector<T>::resizeAndPreserve(const long newNbElement
 
 template<class T> void CrystVector<T>::operator*=(const T num)
 {
-   register T * RESTRICT p=mpData;
+   T * RESTRICT p=mpData;
    for(int i=mNumElements;i>0;i--) *p++ *= num;
 }
 
@@ -233,20 +233,20 @@ template<class T> void CrystVector<T>::operator*=(const CrystVector<T> &vect)
    #endif
    if(mpData!=vect.data())
    {
-      register T * RESTRICT p=mpData;
-      register const T * RESTRICT rhs=vect.data();
+      T * RESTRICT p=mpData;
+      const T * RESTRICT rhs=vect.data();
       for(int i=mNumElements;i>0;i--) { *p *= *rhs; p++ ; rhs++;}
    }
    else
    {
-      register T *p=mpData;
+      T *p=mpData;
       for(int i=mNumElements;i>0;i--) { *p *= *p; p++ ;}
    }
 }
 
 template<class T> void CrystVector<T>::operator/=(const T num)
 {
-   register T * RESTRICT p=mpData;
+   T * RESTRICT p=mpData;
    const REAL d=1/num;
    for(int i=mNumElements;i>0;i--) *p++ *= d;
 }
@@ -263,8 +263,8 @@ template<class T> void CrystVector<T>::operator/=(const CrystVector<T> &vect)
    #endif
    if(mpData!=vect.data())
    {
-      register T * RESTRICT p=mpData;
-      register const T * RESTRICT rhs=vect.data();
+      T * RESTRICT p=mpData;
+      const T * RESTRICT rhs=vect.data();
       for(int i=mNumElements;i>0;i--) { *p /= *rhs; p++ ; rhs++;}
    }
    else *this=1;
@@ -272,7 +272,7 @@ template<class T> void CrystVector<T>::operator/=(const CrystVector<T> &vect)
 
 template<class T> void CrystVector<T>::operator+=(const T num)
 {
-   register T * RESTRICT p=mpData;
+   T * RESTRICT p=mpData;
    for(int i=mNumElements;i>0;i--) *p++ += num;
 }
 
@@ -288,13 +288,13 @@ template<class T> void CrystVector<T>::operator+=(const CrystVector<T> &vect)
    #endif
    if(mpData!=vect.data())
    {
-      register T * RESTRICT p=mpData;
+      T * RESTRICT p=mpData;
       const T * RESTRICT rhs=vect.data();
       for(int i=mNumElements;i>0;i--) *p++ += *rhs++;
    }
    else
    {
-      register T *p=mpData;
+      T *p=mpData;
       for(int i=mNumElements;i>0;i--) {*p += *p; p++;}
    }
 }
@@ -311,7 +311,7 @@ template<class T> void CrystVector<T>::operator-=(const CrystVector<T> &vect)
    #endif
    if(mpData!=vect.data())
    {
-      register T * RESTRICT p=mpData;
+      T * RESTRICT p=mpData;
       const T * RESTRICT rhs=vect.data();
       for(int i=mNumElements;i>0;i--) *p++ -= *rhs++;
    }
@@ -320,7 +320,7 @@ template<class T> void CrystVector<T>::operator-=(const CrystVector<T> &vect)
 
 template<class T> void CrystVector<T>::operator=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=mNumElements;i>0;i--) *p++ = num;
 }
 
@@ -447,8 +447,8 @@ template<class T> CrystMatrix<T>::CrystMatrix(const CrystMatrix &old):
 mNumElements(old.numElements()),mXSize(old.cols()),mYSize(old.rows()),mIsAreference(false)
 {
    mpData=new T[mNumElements];
-   register T *p1=mpData;
-   register const T *p2=old.data();
+   T *p1=mpData;
+   const T *p2=old.data();
    for(long i=0;i<mNumElements;i++) *p1++=*p2++;
 }
 
@@ -474,8 +474,8 @@ template<class T> void CrystMatrix<T>::operator=(const CrystMatrix<T> &old)
       mNumElements=old.numElements();
       mpData=new T[mNumElements];
    }
-   register T *p1=mpData;
-   register const T *p2=old.data();
+   T *p1=mpData;
+   const T *p2=old.data();
    for(long i=0;i<mNumElements;i++) *p1++=*p2++;
 }
 
@@ -495,16 +495,16 @@ template<class T> long CrystMatrix<T>::size()const {return mNumElements;}
 
 template<class T> T CrystMatrix<T>::sum()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    for(long i=0;i<this->numElements();i++) tmp += *p++ ;
    return tmp;
 }
 
 template<class T> T CrystMatrix<T>::min()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -516,8 +516,8 @@ template<class T> T CrystMatrix<T>::min()const
 
 template<class T> T CrystMatrix<T>::max()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -558,8 +558,8 @@ template<class T> void CrystMatrix<T>::resizeAndPreserve(const long ySize,const 
    mXSize=xSize;
    mYSize=ySize;
    if(xSize*ySize == mNumElements) return;
-   register T *p=mpData;
-   register T *p2,*p1;
+   T *p=mpData;
+   T *p2,*p1;
    mpData=0;
    mpData=new T[xSize*ySize];
    p2=mpData;
@@ -576,13 +576,13 @@ template<class T> void CrystMatrix<T>::resizeAndPreserve(const long ySize,const 
 /*
 template<class T> void CrystMatrix<T>::operator=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ = num;
 }
 */
 template<class T> void CrystMatrix<T>::operator*=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ *= num;
 }
 
@@ -595,26 +595,26 @@ template<class T> void CrystMatrix<T>::operator*=(const CrystMatrix<T> &vect)
       //throw 0;
    }
    #endif
-   register T *p=mpData;
-   register const T *rhs=vect.data();
+   T *p=mpData;
+   const T *rhs=vect.data();
    for(int i=0;i<mNumElements;i++) *p++ *= *rhs++;
 }
 
 template<class T> void CrystMatrix<T>::operator/=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ /= num;
 }
 
 template<class T> void CrystMatrix<T>::operator+=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ += num;
 }
 
 template<class T> void CrystMatrix<T>::operator-=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ -= num;
 }
 
@@ -714,8 +714,8 @@ mXSize(old.cols()),mYSize(old.rows()),mZSize(old.depth()),
 mIsAreference(false)
 {
    mpData=new T[mNumElements];
-   register T *p1=mpData;
-   register const T *p2=old.data();
+   T *p1=mpData;
+   const T *p2=old.data();
    for(long i=0;i<mNumElements;i++) *p1++=*p2++;
 }
 
@@ -734,8 +734,8 @@ template<class T> void CrystArray3D<T>::operator=(const CrystArray3D<T> &old)
       if(mIsAreference==false)delete[] mpData ;
       mpData=new T[mNumElements];
    }
-   register T *p1=mpData;
-   register const T *p2=old.data();
+   T *p1=mpData;
+   const T *p2=old.data();
    for(long i=0;i<mNumElements;i++) *p1++=*p2++;
 }
 
@@ -752,16 +752,16 @@ template<class T> long CrystArray3D<T>::size()const{return mNumElements;}
 
 template<class T> T CrystArray3D<T>::sum()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    for(long i=0;i<this->numElements();i++) tmp += *p++ ;
    return tmp;
 }
 
 template<class T> T CrystArray3D<T>::min()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -773,8 +773,8 @@ template<class T> T CrystArray3D<T>::min()const
 
 template<class T> T CrystArray3D<T>::max()const
 {
-   register T tmp=0;
-   register const T *p=this->data();
+   T tmp=0;
+   const T *p=this->data();
    tmp=*p++;
    for(long i=1;i<this->numElements();i++)
    {
@@ -815,8 +815,8 @@ template<class T> void CrystArray3D<T>::resizeAndPreserve(const long zSize,
    mYSize=ySize;
    mZSize=zSize;
    if(xSize*ySize*zSize == mNumElements) return;
-   register T *p=mpData;
-   register T *p2,*p1;
+   T *p=mpData;
+   T *p2,*p1;
    mpData=new T[xSize*ySize*zSize];
    p2=mpData;
    p1=p;
@@ -830,12 +830,12 @@ template<class T> void CrystArray3D<T>::resizeAndPreserve(const long zSize,
 template<class T> void CrystArray3D<T>::operator=(const T num)
 {
    VFN_DEBUG_MESSAGE("CrystArray3D<T>::operator=():"<<num,1)
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ = num;
 }
 template<class T> void CrystArray3D<T>::operator*=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ *= num;
 }
 
@@ -848,26 +848,26 @@ template<class T> void CrystArray3D<T>::operator*=(const CrystArray3D<T> &vect)
       //throw 0;
    }
    #endif
-   register T *p=mpData;
-   register const T *rhs=vect.data();
+   T *p=mpData;
+   const T *rhs=vect.data();
    for(int i=0;i<mNumElements;i++) *p++ *= *rhs++;
 }
 
 template<class T> void CrystArray3D<T>::operator/=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ /= num;
 }
 
 template<class T> void CrystArray3D<T>::operator+=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ += num;
 }
 
 template<class T> void CrystArray3D<T>::operator-=(const T num)
 {
-   register T *p=mpData;
+   T *p=mpData;
    for(int i=0;i<mNumElements;i++) *p++ -= num;
 }
 

--- a/ObjCryst/ObjCryst/ScatteringData.cpp
+++ b/ObjCryst/ObjCryst/ScatteringData.cpp
@@ -1752,7 +1752,7 @@ void ScatteringData::CalcGeomStructFactor() const
                const long * RESTRICT intK=mIntK.data();
                const long * RESTRICT intL=mIntL.data();
 
-               register long * RESTRICT tmpInt=intVect.data();
+               long * RESTRICT tmpInt=intVect.data();
                // :KLUDGE: using a AND to bring back within [0;sLibCrystNbTabulSine[ may
                // not be portable, depending on the model used to represent signed integers
                // a test should be added to throw up in that case.
@@ -1787,9 +1787,9 @@ void ScatteringData::CalcGeomStructFactor() const
                const REAL x=allCoords(j,0);
                const REAL y=allCoords(j,1);
                const REAL z=allCoords(j,2);
-               const register REAL *hh=mH2Pi.data();
-               const register REAL *kk=mK2Pi.data();
-               const register REAL *ll=mL2Pi.data();
+               const REAL *hh=mH2Pi.data();
+               const REAL *kk=mK2Pi.data();
+               const REAL *ll=mL2Pi.data();
 
                #ifdef HAVE_SSE_MATHFUN
                #if 0
@@ -1942,7 +1942,7 @@ void ScatteringData::CalcGeomStructFactor() const
                }
                #endif
                #else
-               register REAL *tmp=tmpVect.data();
+               REAL *tmp=tmpVect.data();
                for(int jj=0;jj<mNbReflUsed;jj++) *tmp++ = *hh++ * x + *kk++ * y + *ll++ *z;
 
                REAL *sf=mvRealGeomSF[pScattPow].data();
@@ -1966,9 +1966,9 @@ void ScatteringData::CalcGeomStructFactor() const
          if( (pSpg->GetSpaceGroupNumber()>= 143) && (pSpg->GetSpaceGroupNumber()<= 167))
          {//Special case for trigonal groups R3,...
             REAL * RESTRICT p1=tmpVect.data();
-            const register REAL * RESTRICT hh=mH2Pi.data();
-            const register REAL * RESTRICT kk=mK2Pi.data();
-            const register REAL * RESTRICT ll=mL2Pi.data();
+            const REAL * RESTRICT hh=mH2Pi.data();
+            const REAL * RESTRICT kk=mK2Pi.data();
+            const REAL * RESTRICT ll=mL2Pi.data();
             for(long j=mNbReflUsed;j>0;j--) *p1++ += 2*cos((*hh++ - *kk++ - *ll++)/3.);
          }
          else
@@ -1979,9 +1979,9 @@ void ScatteringData::CalcGeomStructFactor() const
                const REAL y=(*pTransVect)[j].tr[1];
                const REAL z=(*pTransVect)[j].tr[2];
                REAL *p1=tmpVect.data();
-               const register REAL *hh=mH2Pi.data();
-               const register REAL *kk=mK2Pi.data();
-               const register REAL *ll=mL2Pi.data();
+               const REAL *hh=mH2Pi.data();
+               const REAL *kk=mK2Pi.data();
+               const REAL *ll=mL2Pi.data();
                for(long j=mNbReflUsed;j>0;j--) *p1++ += cos(*hh++ *x + *kk++ *y + *ll++ *z );
             }
          }
@@ -2131,9 +2131,9 @@ void ScatteringData::CalcGeomStructFactor_FullDeriv(std::set<RefinablePar*> &vPa
       if( (pSpg->GetSpaceGroupNumber()>= 143) && (pSpg->GetSpaceGroupNumber()<= 167))
       {//Special case for trigonal groups R3,...
          REAL * RESTRICT p1=transMult.data();
-         const register REAL * RESTRICT hh=mH2Pi.data();
-         const register REAL * RESTRICT kk=mK2Pi.data();
-         const register REAL * RESTRICT ll=mL2Pi.data();
+         const REAL * RESTRICT hh=mH2Pi.data();
+         const REAL * RESTRICT kk=mK2Pi.data();
+         const REAL * RESTRICT ll=mL2Pi.data();
          for(long j=mNbReflUsed;j>0;j--) *p1++ += 2*cos((*hh++ - *kk++ - *ll++)/3.);
       }
       else
@@ -2144,9 +2144,9 @@ void ScatteringData::CalcGeomStructFactor_FullDeriv(std::set<RefinablePar*> &vPa
             const REAL y=(*pTransVect)[j].tr[1];
             const REAL z=(*pTransVect)[j].tr[2];
             REAL *p1=transMult.data();
-            const register REAL * RESTRICT hh=mH2Pi.data();
-            const register REAL * RESTRICT kk=mK2Pi.data();
-            const register REAL * RESTRICT ll=mL2Pi.data();
+            const REAL * RESTRICT hh=mH2Pi.data();
+            const REAL * RESTRICT kk=mK2Pi.data();
+            const REAL * RESTRICT ll=mL2Pi.data();
             for(long j=mNbReflUsed;j>0;j--) *p1++ += cos(*hh++ *x + *kk++ *y + *ll++ *z );
          }
       }
@@ -2175,9 +2175,9 @@ void ScatteringData::CalcGeomStructFactor_FullDeriv(std::set<RefinablePar*> &vPa
          {
             REAL *pc=c.data();
             REAL *ps=s.data();
-            const register REAL *hh=mH2Pi.data();
-            const register REAL *kk=mK2Pi.data();
-            const register REAL *ll=mL2Pi.data();
+            const REAL *hh=mH2Pi.data();
+            const REAL *kk=mK2Pi.data();
+            const REAL *ll=mL2Pi.data();
             #ifdef HAVE_SSE_MATHFUN
             const v4sf v4x=_mm_load1_ps(&x);
             const v4sf v4y=_mm_load1_ps(&y);
@@ -2238,12 +2238,12 @@ void ScatteringData::CalcGeomStructFactor_FullDeriv(std::set<RefinablePar*> &vPa
                mvImagGeomSF_FullDeriv[*par][pScattPow]=0;
             }
             pSpg->GetSymmetric(j,dx,dy,dz,true,true,true);
-            const register REAL *hh=mH2Pi.data();
-            const register REAL *kk=mK2Pi.data();
-            const register REAL *ll=mL2Pi.data();
-            const register REAL *pmult=transMult.data();
-            register REAL *rsf=mvRealGeomSF_FullDeriv[*par][pScattPow].data();
-            register REAL *isf=mvImagGeomSF_FullDeriv[*par][pScattPow].data();
+            const REAL *hh=mH2Pi.data();
+            const REAL *kk=mK2Pi.data();
+            const REAL *ll=mL2Pi.data();
+            const REAL *pmult=transMult.data();
+            REAL *rsf=mvRealGeomSF_FullDeriv[*par][pScattPow].data();
+            REAL *isf=mvImagGeomSF_FullDeriv[*par][pScattPow].data();
             VFN_DEBUG_MESSAGE("ScatteringData::CalcGeomStructFactor_FullDeriv()comp="<<i<<", par="<<(*par)->GetName()<<", rs="<<mvRealGeomSF_FullDeriv[*par][pScattPow].size(),1)
             const REAL *pc=c.data();
             const REAL *ps=s.data();

--- a/ObjCryst/ObjCryst/ScatteringPower.cpp
+++ b/ObjCryst/ObjCryst/ScatteringPower.cpp
@@ -522,8 +522,10 @@ CrystVector_REAL ScatteringPowerAtom::GetScatteringFactor(const ScatteringData &
             const long nb=data.GetSinThetaOverLambda().numElements();
             const REAL *pstol=data.GetSinThetaOverLambda().data();
             for(long i=0;i<nb;i++)
+            {
                sf(i)=(z-mpGaussian->at_stol(*pstol))/(*pstol * *pstol);
                pstol++;
+            }
          }
          else sf=1.0;//:KLUDGE:  Should never happen
          break;

--- a/ObjCryst/RefinableObj/LSQNumObj.cpp
+++ b/ObjCryst/RefinableObj/LSQNumObj.cpp
@@ -214,23 +214,23 @@ void LSQNumObj::Refine (int nbCycle,bool useLevenbergMarquardt,
          {
             #if 1
             {
-               const register REAL * RESTRICT pD=designMatrix.data()+i*designMatrix.cols();
-               const register REAL * RESTRICT pW=mWeight.data();
+               const REAL * RESTRICT pD=designMatrix.data()+i*designMatrix.cols();
+               const REAL * RESTRICT pW=mWeight.data();
                REAL * RESTRICT p=tmpV1.data();
                for(k=0;k<nbObs;k++) *p++ = *pD++ * *pW++;
             }
-            const register REAL * pD=designMatrix.data();
+            const REAL * pD=designMatrix.data();
             for(j=0;j<nbVar;j++)
             {
-               const register REAL * p1=tmpV1.data();
+               const REAL * p1=tmpV1.data();
                REAL v2=0;
                for(k=0;k<nbObs;k++) v2+= *pD++ * *p1++;
                M(j,i)=v2;
             }
             REAL b=0;
-            const register REAL * pObs=mObs.data();
-            const register REAL * pCalc=calc0.data();
-            const register REAL * p1=tmpV1.data();
+            const REAL * pObs=mObs.data();
+            const REAL * pCalc=calc0.data();
+            const REAL * p1=tmpV1.data();
             for(k=0;k<nbObs;k++) b+= (*pObs++ - *pCalc++)* *p1++;
             B(i)=b;
             #else

--- a/ObjCryst/wxCryst/trackball.c
+++ b/ObjCryst/wxCryst/trackball.c
@@ -94,7 +94,7 @@ vsub(const float *src1, const float *src2, float *dst)
 void
 vcopy(const float *v1, float *v2)
 {
-    register int i;
+    int i;
     for (i = 0 ; i < 3 ; i++)
         v2[i] = v1[i];
 }


### PR DESCRIPTION
Fix warnings that show when building diffpy/libobjcryst using the Anaconda Python compiler packages, i.e., the latest g++ and clang++.