### PR TITLE
Remove GL functions when OBJCRYST_GL is undefined.

### DIFF
--- a/ObjCryst/ObjCryst/Atom.cpp
+++ b/ObjCryst/ObjCryst/Atom.cpp
@@ -291,6 +291,7 @@ ostream& Atom::POVRayDescription(ostream &os,
    return os;
 }
 
+#ifdef OBJCRYST_GL
 void Atom::GLInitDisplayList(const bool onlyIndependentAtoms,
                              const REAL xMin,const REAL xMax,
                              const REAL yMin,const REAL yMax,
@@ -301,7 +302,6 @@ void Atom::GLInitDisplayList(const bool onlyIndependentAtoms,
                              const REAL fadeDistance,
                              const bool fullMoleculeInLimits)const
 {
-   #ifdef OBJCRYST_GL
    VFN_DEBUG_MESSAGE("Atom::GLInitDisplayList():"<<this->GetName(),5)
    REAL en=1;
    if(displayEnantiomer==true) en=-1;
@@ -469,8 +469,8 @@ void Atom::GLInitDisplayList(const bool onlyIndependentAtoms,
    }
    gluDeleteQuadric(pQuadric);
    VFN_DEBUG_MESSAGE("Atom::GLInitDisplayList():End",5)
-   #endif
 }
+#endif  // OBJCRYST_GL
 
 bool Atom::IsDummy()const { if(0==mScattCompList(0).mpScattPow) return true; return false;}
 

--- a/ObjCryst/ObjCryst/Atom.h
+++ b/ObjCryst/ObjCryst/Atom.h
@@ -127,6 +127,7 @@ class Atom: public Scatterer
       virtual ostream& POVRayDescription(ostream &os,
                                          const CrystalPOVRayOptions &options)const;
 
+#ifdef OBJCRYST_GL
       virtual void GLInitDisplayList(const bool noSymmetrics=false,
                                      const REAL xMin=-.1,const REAL xMax=1.1,
                                      const REAL yMin=-.1,const REAL yMax=1.1,
@@ -136,6 +137,7 @@ class Atom: public Scatterer
                                      const bool hideHydrogens=false,
                                      const REAL fadeDistance=0,
                                      const bool fullMoleculeInLimits=false)const;
+#endif    // OBJCRYST_GL
 
       /// Is this a dummy atom ? (ie no ScatteringPower)
       /// Dummy atoms should not exist !

--- a/ObjCryst/ObjCryst/Crystal.cpp
+++ b/ObjCryst/ObjCryst/Crystal.cpp
@@ -543,6 +543,7 @@ ostream& Crystal::POVRayDescription(ostream &os,const CrystalPOVRayOptions &opti
    return os;
 }
 
+#ifdef OBJCRYST_GL
 void Crystal::GLInitDisplayList(const bool onlyIndependentAtoms,
                                 const REAL xMin,const REAL xMax,
                                 const REAL yMin,const REAL yMax,
@@ -553,7 +554,6 @@ void Crystal::GLInitDisplayList(const bool onlyIndependentAtoms,
                                 const bool fullMoleculeInLimits)const
 {
    VFN_DEBUG_ENTRY("Crystal::GLInitDisplayList()",5)
-   #ifdef OBJCRYST_GL
       REAL en=1;// if -1, display enantiomeric structure
       if(mDisplayEnantiomer.GetChoice()==1) en=-1;
 
@@ -702,11 +702,10 @@ void Crystal::GLInitDisplayList(const bool onlyIndependentAtoms,
                                                    displayEnantiomer,displayNames,hideHydrogens,fadeDistance,fullMoleculeInLimits);
          }
       glPopMatrix();
-   #else
    cout << "Crystal::GLView(): Compiled without OpenGL support !" <<endl;
-   #endif
    VFN_DEBUG_EXIT("Crystal::GLInitDisplayList(bool)",5)
 }
+#endif  // OBJCRYST_GL
 
 void Crystal::CalcDynPopCorr(const REAL overlapDist, const REAL mergeDist) const
 {

--- a/ObjCryst/ObjCryst/Crystal.h
+++ b/ObjCryst/ObjCryst/Crystal.h
@@ -224,6 +224,7 @@ class Crystal:public UnitCell
       */
       ostream& POVRayDescription(ostream &os,const CrystalPOVRayOptions &options)const;
 
+#ifdef OBJCRYST_GL
       /** Create an OpenGL DisplayList of the crystal.
       * \param onlyIndependentAtoms if false (the default), then all symmetrics
       * are displayed within the given limits
@@ -245,6 +246,7 @@ class Crystal:public UnitCell
                                      const bool hideHydrogens=false,
                                      const REAL fadeDistance=0,
                                      const bool fullMoleculeInLimits=false)const;
+#endif  // OBJCRYST_GL
 
       /** \internal \brief Compute the 'Dynamical population correction for all atoms.
       * Atoms which are considered "equivalent" (ie currently with the same Z number)

--- a/ObjCryst/ObjCryst/Molecule.cpp
+++ b/ObjCryst/ObjCryst/Molecule.cpp
@@ -3419,6 +3419,7 @@ ostream& Molecule::POVRayDescription(ostream &os,const CrystalPOVRayOptions &opt
    return os;
 }
 
+#ifdef OBJCRYST_GL
 void Molecule::GLInitDisplayList(const bool onlyIndependentAtoms,
                                const REAL xMin,const REAL xMax,
                                const REAL yMin,const REAL yMax,
@@ -3429,7 +3430,6 @@ void Molecule::GLInitDisplayList(const bool onlyIndependentAtoms,
                                const REAL fadeDistance,
                                const bool fullMoleculeInLimits)const
 {
-   #ifdef OBJCRYST_GL
    VFN_DEBUG_ENTRY("Molecule::GLInitDisplayList()",3)
    if(mvpAtom.size()==0)
    {
@@ -3827,8 +3827,8 @@ void Molecule::GLInitDisplayList(const bool onlyIndependentAtoms,
    }//else
    gluDeleteQuadric(pQuadric);
    VFN_DEBUG_EXIT("Molecule::GLInitDisplayList()",3)
-   #endif //GLCryst
 }
+#endif  // OBJCRYST_GL
 
 void Molecule::AddAtom(const REAL x, const REAL y, const REAL z,
                        const ScatteringPower *pPow, const string &name,

--- a/ObjCryst/ObjCryst/Molecule.h
+++ b/ObjCryst/ObjCryst/Molecule.h
@@ -781,6 +781,8 @@ class Molecule: public Scatterer
       virtual string GetComponentName(const int i) const;
       virtual ostream& POVRayDescription(ostream &os,
                                          const CrystalPOVRayOptions &options)const;
+
+#ifdef OBJCRYST_GL
       virtual void GLInitDisplayList(const bool onlyIndependentAtoms=false,
                                      const REAL xMin=-.1,const REAL xMax=1.1,
                                      const REAL yMin=-.1,const REAL yMax=1.1,
@@ -790,6 +792,8 @@ class Molecule: public Scatterer
                                      const bool hideHydrogens=false,
                                      const REAL fadeDistance=0,
                                      const bool fullMoleculeInLimits=false)const;
+#endif  // OBJCRYST_GL
+
       /** Add an atom
       *
       *

--- a/ObjCryst/ObjCryst/Scatterer.h
+++ b/ObjCryst/ObjCryst/Scatterer.h
@@ -229,6 +229,8 @@ class Scatterer:virtual public RefinableObj
       */
       virtual ostream& POVRayDescription(ostream &os,
                                          const CrystalPOVRayOptions &options)const=0;
+
+#ifdef OBJCRYST_GL
       /** \internal Create an OpenGL Display List of the scatterer. This should only
       * be called by a Crystal object.
       *
@@ -255,6 +257,8 @@ class Scatterer:virtual public RefinableObj
                                      const bool hideHydrogens=false,
                                      const REAL fadeDistance=0,
                                      const bool fullMoleculeInLimits=false)const=0;
+#endif  // OBJCRYST_GL
+
       /// Last time anything in the scatterer was changed (atoms, positions, scattering power)
       const RefinableObjClock& GetClockScatterer()const;
       /// Last time anything in the scatterer was changed (atoms, positions, scattering power)

--- a/ObjCryst/ObjCryst/ZScatterer.cpp
+++ b/ObjCryst/ObjCryst/ZScatterer.cpp
@@ -643,6 +643,7 @@ ostream& ZScatterer::POVRayDescription(ostream &os,
    return os;
 }
 
+#ifdef OBJCRYST_GL
 void ZScatterer::GLInitDisplayList(const bool onlyIndependentAtoms,
                                    const REAL xMin,const REAL xMax,
                                    const REAL yMin,const REAL yMax,
@@ -653,7 +654,6 @@ void ZScatterer::GLInitDisplayList(const bool onlyIndependentAtoms,
                                    const REAL fadeDistance,
                                    const bool fullMoleculeInLimits)const
 {
-   #ifdef OBJCRYST_GL
    VFN_DEBUG_ENTRY("ZScatterer::GLInitDisplayList()",4)
    if(mZAtomRegistry.GetNb()==0)
    {
@@ -1066,8 +1066,8 @@ void ZScatterer::GLInitDisplayList(const bool onlyIndependentAtoms,
    }//else
    gluDeleteQuadric(pQuadric);
    VFN_DEBUG_EXIT("ZScatterer::GLInitDisplayList()",4)
-   #endif //GLCryst
 }
+#endif  // OBJCRYST_GL
 
 void ZScatterer::SetUseGlobalScatteringPower(const bool useIt)
 {

--- a/ObjCryst/ObjCryst/ZScatterer.h
+++ b/ObjCryst/ObjCryst/ZScatterer.h
@@ -275,6 +275,7 @@ class ZScatterer: public Scatterer
       virtual ostream& POVRayDescription(ostream &os,
                                          const CrystalPOVRayOptions &options)const;
 
+#ifdef OBJCRYST_GL
       virtual void GLInitDisplayList(const bool onlyIndependentAtoms=false,
                                      const REAL xMin=-.1,const REAL xMax=1.1,
                                      const REAL yMin=-.1,const REAL yMax=1.1,
@@ -284,6 +285,8 @@ class ZScatterer: public Scatterer
                                      const bool hideHydrogens=false,
                                      const REAL fadeDistance=0,
                                      const bool fullMoleculeInLimits=false)const;
+#endif  // OBJCRYST_GL
+
       /** \brief use a Global scattering power for this scatterer ?
       *
       * If true, then the overall scattering power of this ZScatterer will be


### PR DESCRIPTION
The GLInitDisplayList methods were no-op for undefined OBJCRYST_GL.
Here we remove them altogether.  This simplifies diffpy/pyobjcryst
wrappers, because changes to GL-related interfaces have no impact
on the wrapped classes.