### PR TITLE
Fix leak in CrystVector reported by valgrind

### DIFF
--- a/ObjCryst/CrystVector/CrystVector.cpp
+++ b/ObjCryst/CrystVector/CrystVector.cpp
@@ -182,7 +182,7 @@ template<class T> void CrystVector<T>::resize(const long newNbElements)
    if(mNumElements==newNbElements) return;
    VFN_DEBUG_MESSAGE("CrystVector<T>::resize():("<<mNumElements<<"->"
       <<newNbElements<<").",0)
-   if((mIsAreference==false) && (mNumElements != 0))
+   if(!mIsAreference)
    {
       delete[] mpData ;
    }


### PR DESCRIPTION
I have tested libdiffpy linked with ObjCryst with valgrind and it reported some leaks in CrystVector.
This should address that.

---

Problem: Copy constructor of CrystVector allocates zero-length
buffer, but resize() method does not delete it.
https://github.com/vincefn/objcryst/blob/65ab262c33f7528f26f6dac1ff1a1103e7b2099d/ObjCryst/CrystVector/CrystVector.cpp#L58-L61

Solution: Always delete the old buffer unless a reference.  The
pointer for unallocated buffer is NULL so its deletion is safe.