### PR TITLE
Fix misleading debug message

### DIFF
--- a/ObjCryst/ObjCryst/Molecule.cpp
+++ b/ObjCryst/ObjCryst/Molecule.cpp
@@ -7676,7 +7676,7 @@ vector<MolAtom*>::reverse_iterator Molecule::FindAtom(const string &name)
    for(rpos=mvpAtom.rbegin();rpos!=mvpAtom.rend();++rpos)
       if(name==(*rpos)->GetName())
       {
-         VFN_DEBUG_EXIT("Molecule::FindAtom():"<<name<<"...NOT FOUND !",4)
+         VFN_DEBUG_EXIT("Molecule::FindAtom():"<<name<<"...FOUND !",4)
          return rpos;
       }
    VFN_DEBUG_EXIT("Molecule::FindAtom():"<<name<<"...NOT FOUND !",4)


### PR DESCRIPTION
@vincefn - I found this typo while tracking down segfault crash in pyobjcryst on
`Molecule.GetAtom("invalid-name")`.

It seems that there is no argument check in `GetAtom` so I guess
I need to use `FindAtom` instead to handle non-existing names, correct?