### PR TITLE
Fix spacegroup recursion

### DIFF
--- a/ObjCryst/ObjCryst/SpaceGroup.cpp
+++ b/ObjCryst/ObjCryst/SpaceGroup.cpp
@@ -581,27 +581,29 @@ void SpaceGroup::InitSpaceGroup(const string &spgId)
    #endif
    try
    {
+      // replace mpCCTbxSpaceGroup only after we get new space group
       cctbx::sgtbx::space_group_symbols sgs=cctbx::sgtbx::space_group_symbols(spgId);
-      if(mpCCTbxSpaceGroup!=0) delete mpCCTbxSpaceGroup;
-      mpCCTbxSpaceGroup=0;
-      mpCCTbxSpaceGroup = new cctbx::sgtbx::space_group(sgs);
+      cctbx::sgtbx::space_group *nsg = new cctbx::sgtbx::space_group(sgs);
+      assert(nsg);
+      delete mpCCTbxSpaceGroup;
+      mpCCTbxSpaceGroup = nsg;
    }
-   catch(exception &ex1)
+   catch(cctbx::error ex1)
    {
       try
       {
-         (*fpObjCrystInformUser)("Failed lookup symbol ! try Hall symbol ?");
-         if(mpCCTbxSpaceGroup!=0) delete mpCCTbxSpaceGroup;
-         mpCCTbxSpaceGroup=0;
-         mpCCTbxSpaceGroup = new cctbx::sgtbx::space_group(spgId);
+         (*fpObjCrystInformUser)("Lookup of '" + spgId + "' symbol failed, trying as Hall symbol.");
+         // replace mpCCTbxSpaceGroup only after we get new space group
+         cctbx::sgtbx::space_group *nsg = new cctbx::sgtbx::space_group(spgId);
+         assert(nsg);
+         delete mpCCTbxSpaceGroup;
+         mpCCTbxSpaceGroup = nsg;
       }
-      catch(exception &ex2)
+      catch(cctbx::error ex2)
       {
          (*fpObjCrystInformUser)("Could not interpret Spacegroup Symbol:"+spgId);
-         (*fpObjCrystInformUser)("Reverting to spacegroup symbol:"+mId);
-         this->InitSpaceGroup(mId);
-         VFN_DEBUG_EXIT("SpaceGroup::InitSpaceGroup() could not interpret spacegroup:"<<spgId<<":"<<ex1.what()<<":"<<ex2.what(),8)
-         return;
+         string emsg = "Space group symbol '" + spgId + "' not recognized";
+         throw ObjCrystException(emsg);
       }
    }
 

--- a/ObjCryst/ObjCryst/SpaceGroup.cpp
+++ b/ObjCryst/ObjCryst/SpaceGroup.cpp
@@ -644,13 +644,17 @@ void SpaceGroup::InitSpaceGroup(const string &spgId)
 
       mExtension='\0'; //this->GetCCTbxSpg().type().extension();
    }
-   catch(exception &ex)
+   catch(cctbx::error ex)
    {
       (*fpObjCrystInformUser)("Error initializing spacegroup (Incorrect Hall symbol ?):"+spgId);
-      this->InitSpaceGroup(mId);
-      (*fpObjCrystInformUser)("Reverting to spacegroup symbol:"+mId);
+      if (mId != spgId)
+      {
+         (*fpObjCrystInformUser)("Reverting to spacegroup symbol:"+mId);
+         this->InitSpaceGroup(mId);
+      }
       VFN_DEBUG_EXIT("SpaceGroup::InitSpaceGroup() could not interpret spacegroup:"<<spgId<<":"<<ex.what(),8)
-      return;
+      string emsg = "Space group symbol '" + spgId + "' not recognized";
+      throw ObjCrystException(emsg);
    }
 
    mExtension=this->GetCCTbxSpg().match_tabulated_settings().extension();


### PR DESCRIPTION
Fix segfault due to infinite recursion from `SpaceGroup("invalid")`.
Throw ObjCrystException for invalid SG name in constructor and `ChangeSpaceGroup`.

I am not sure we need the second [try-catch guard](https://github.com/pavoljuhas/objcryst/blob/1dadd873d8c528bacad6ebc7c336b373ce406beb/ObjCryst/ObjCryst/SpaceGroup.cpp#L610-L646), because at that point the `mpCCTbxSpaceGroup` exists.
Perhaps that try-catch guard can be removed

I am attaching two example source files to test the behavior with invalid SG names.

[tsg1.cpp.txt](https://github.com/vincefn/objcryst/files/3167809/tsg1.cpp.txt) - test constructor
[tsg2.cpp.txt](https://github.com/vincefn/objcryst/files/3167810/tsg2.cpp.txt) - test ChangeSpaceGroup
