### PR TITLE
Add SetPowderPatternObsSigma

### DIFF
--- a/Fox/src/Fox.cpp
+++ b/Fox/src/Fox.cpp
@@ -1018,7 +1018,7 @@ int main (int argc, char *argv[])
                     } else {
                         wxMessageDialog d(NULL,_T("Failed loading file:\n")+name,_T("Error"),wxOK|wxICON_ERROR);
                         d.ShowModal();
-                    }                    
+                    }
               };
             }
             else
@@ -1047,7 +1047,7 @@ int main (int argc, char *argv[])
                      } else {
                         wxMessageDialog d(NULL,_T("Failed loading file:\n")+name,_T("Error"),wxOK|wxICON_ERROR);
                         d.ShowModal();
-                     } 
+                     }
                   };
                }
             }

--- a/Fox/src/foxgrid/FoxGridSlave.cpp
+++ b/Fox/src/foxgrid/FoxGridSlave.cpp
@@ -347,7 +347,7 @@ void FoxGridSlave::CheckJobsAndStartCalculation()
                 WriteLogMessage("ERROR: Can't write a file " + proc->dir + _T("\\input.xml"));
                 return;
             }
-            
+
             wxString cmd_content;
             wxString appname = wxApp::GetInstance()->argv[0];
             if(rand) {

--- a/ObjCryst/ObjCryst/PowderPattern.cpp
+++ b/ObjCryst/ObjCryst/PowderPattern.cpp
@@ -3862,6 +3862,21 @@ supplied vector of observed intensities does not have the expected number of poi
       (*fpObjCrystInformUser)((string)buf);
    }
 }
+
+void PowderPattern::SetPowderPatternObsSigma(const CrystVector_REAL& sigma)
+{
+   VFN_DEBUG_MESSAGE("PowderPattern::SetPowderPatternObsSigma()",5)
+   if((unsigned long)sigma.numElements() != mNbPoint)
+   {
+      throw(ObjCrystException("PowderPattern::SetPowderPatternObsSigma(vect): The \
+supplied vector of sigma does not have the expected number of points!"));
+   }
+
+   mPowderPatternObsSigma = sigma;
+   mPowderPatternWeight.resize(mNbPoint);
+   this->SetWeightToInvSigmaSq();
+   mClockIntegratedFactorsPrep.Reset();
+}
 void PowderPattern::SavePowderPattern(const string &filename) const
 {
    VFN_DEBUG_MESSAGE("PowderPattern::SavePowderPattern",5)

--- a/ObjCryst/ObjCryst/PowderPattern.h
+++ b/ObjCryst/ObjCryst/PowderPattern.h
@@ -816,6 +816,8 @@ class PowderPattern : public RefinableObj
          * for example by calling DiffractionDataPowder::InitPowderPatternPar().
          */
          void SetPowderPatternObs(const CrystVector_REAL& obs);
+         /// Set sigma for each point of the observed powder pattern.
+         void SetPowderPatternObsSigma(const CrystVector_REAL& sigma);
 
          ///Save powder pattern to one file, text format, 3 columns theta Iobs Icalc.
          ///If Iobs is missing, the column is omitted.


### PR DESCRIPTION
Add function `PowderPattern::SetPowderPatternObsSigma` to manually set sigma values from data. 

(There exists `ImportPowderPattern2ThetaObsSigma` but it requires reading from a file.)

Used in https://github.com/diffpy/pyobjcryst/pull/84.