### PR TITLE
Implement isotropic peak broadening to isotropic pseudo-Voigt profile

### DIFF
--- a/ObjCryst/ObjCryst/PowderPattern.cpp
+++ b/ObjCryst/ObjCryst/PowderPattern.cpp
@@ -881,11 +881,12 @@ pair<const CrystVector_REAL*,const RefinableObjClock*>
 
 void PowderPatternDiffraction::SetReflectionProfilePar(const ReflectionProfileType prof,
                                                        const REAL w, const REAL u, const REAL v,
-                                                       const REAL eta0, const REAL eta1)
+                                                       const REAL eta0, const REAL eta1,
+                                                       const REAL scherrerP)
 {
    VFN_DEBUG_MESSAGE("PowderPatternDiffraction::SetReflectionProfilePar()",5)
    ReflectionProfilePseudoVoigt* p=new ReflectionProfilePseudoVoigt();
-   p->SetProfilePar(w,u,v,eta0,eta1);
+   p->SetProfilePar(w,u,v,eta0,eta1,scherrerP);
    this->SetProfile(p);
 }
 

--- a/ObjCryst/ObjCryst/PowderPattern.h
+++ b/ObjCryst/ObjCryst/PowderPattern.h
@@ -356,7 +356,8 @@ class PowderPatternDiffraction : virtual public PowderPatternComponent,public Sc
                                    const REAL fwhmCagliotiU=0,
                                    const REAL fwhmCagliotiV=0,
                                    const REAL eta0=0.5,
-                                   const REAL eta1=0.);
+                                   const REAL eta1=0.,
+                                   const REAL scherrerP=0.);
       /** Assign a new profile
       *
       */

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -261,7 +261,7 @@ void ReflectionProfilePseudoVoigt::InitParameters()
       this->AddPar(tmp);
    }
    {
-      RefinablePar tmp("P",&mScherrerP,-1./RAD2DEG/RAD2DEG,1./RAD2DEG/RAD2DEG,
+      RefinablePar tmp("P",&mScherrerP,0,1e-3,
                         gpRefParTypeScattDataProfileWidth,
                         REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
       tmp.AssignClock(mClockMaster);
@@ -883,7 +883,7 @@ void ReflectionProfilePseudoVoigtAnisotropic::InitParameters()
       this->AddPar(tmp);
    }
    {
-      RefinablePar tmp("P",&mScherrerP,-1./RAD2DEG/RAD2DEG,1./RAD2DEG/RAD2DEG,
+      RefinablePar tmp("P",&mScherrerP,0,3e-4,
                        gpRefParTypeScattDataProfileWidth,
                        REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
       tmp.AssignClock(mClockMaster);

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -138,11 +138,10 @@ CrystVector_REAL ReflectionProfilePseudoVoigt::GetProfile(const CrystVector_REAL
                             const REAL center,const REAL h, const REAL k, const REAL l)const
 {
    VFN_DEBUG_ENTRY("ReflectionProfilePseudoVoigt::GetProfile(),c="<<center,2)
-   const REAL costheta=cos(center/2.0);
    REAL fwhm= mCagliotiW
              +mCagliotiV*tan(center/2.0)
              +mCagliotiU*pow(tan(center/2.0),2)
-             +mScherrerP/(costheta*costheta);
+             +mScherrerP/pow(cos(center/2.0),2);
    if(fwhm<=0)
    {
       VFN_DEBUG_MESSAGE("ReflectionProfilePseudoVoigt::GetProfile(): fwhm**2<0 ! "
@@ -197,11 +196,10 @@ REAL ReflectionProfilePseudoVoigt::GetFullProfileWidth(const REAL relativeIntens
    const int halfnb=nb/2;
    CrystVector_REAL x(nb);
    REAL n=5.0;
-   const REAL costheta=cos(center/2.0);
    REAL fwhm= mCagliotiW
              +mCagliotiV*tan(center/2.0)
              +mCagliotiU*pow(tan(center/2.0),2)
-             +mScherrerP/(costheta*costheta);
+             +mScherrerP/pow(cos(center/2.0),2);
    if(fwhm<=0) fwhm=1e-6;
    else fwhm=sqrt(fwhm);
    CrystVector_REAL prof;

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -90,7 +90,7 @@ bool ReflectionProfile::IsAnisotropic()const
 ////////////////////////////////////////////////////////////////////////
 ReflectionProfilePseudoVoigt::ReflectionProfilePseudoVoigt():
 ReflectionProfile(),
-mCagliotiU(0),mCagliotiV(0),mCagliotiW(.01*DEG2RAD*DEG2RAD),
+mCagliotiU(0),mCagliotiV(0),mCagliotiW(.01*DEG2RAD*DEG2RAD),mScherrerP(0),
 mPseudoVoigtEta0(0.5),mPseudoVoigtEta1(0.0),
 mAsymBerarBaldinozziA0(0.0),mAsymBerarBaldinozziA1(0.0),
 mAsymBerarBaldinozziB0(0.0),mAsymBerarBaldinozziB1(0.0),
@@ -101,7 +101,7 @@ mAsym0(1.0),mAsym1(0.0),mAsym2(0.0)
 
 ReflectionProfilePseudoVoigt::ReflectionProfilePseudoVoigt
    (const ReflectionProfilePseudoVoigt &old):
-mCagliotiU(old.mCagliotiU),mCagliotiV(old.mCagliotiV),mCagliotiW(old.mCagliotiW),
+mCagliotiU(old.mCagliotiU),mCagliotiV(old.mCagliotiV),mCagliotiW(old.mCagliotiW),mScherrerP(old.mScherrerP),
 mPseudoVoigtEta0(old.mPseudoVoigtEta0),mPseudoVoigtEta1(old.mPseudoVoigtEta1),
 mAsymBerarBaldinozziA0(old.mAsymBerarBaldinozziA0),
 mAsymBerarBaldinozziA1(old.mAsymBerarBaldinozziA1),
@@ -138,9 +138,11 @@ CrystVector_REAL ReflectionProfilePseudoVoigt::GetProfile(const CrystVector_REAL
                             const REAL center,const REAL h, const REAL k, const REAL l)const
 {
    VFN_DEBUG_ENTRY("ReflectionProfilePseudoVoigt::GetProfile(),c="<<center,2)
+   const REAL costheta=cos(center/2.0);
    REAL fwhm= mCagliotiW
              +mCagliotiV*tan(center/2.0)
-             +mCagliotiU*pow(tan(center/2.0),2);
+             +mCagliotiU*pow(tan(center/2.0),2)
+             +mScherrerP/(costheta*costheta);
    if(fwhm<=0)
    {
       VFN_DEBUG_MESSAGE("ReflectionProfilePseudoVoigt::GetProfile(): fwhm**2<0 ! "
@@ -174,13 +176,15 @@ void ReflectionProfilePseudoVoigt::SetProfilePar(const REAL fwhmCagliotiW,
                    const REAL fwhmCagliotiU,
                    const REAL fwhmCagliotiV,
                    const REAL eta0,
-                   const REAL eta1)
+                   const REAL eta1,
+                   const REAL scherrerP)
 {
    mCagliotiU=fwhmCagliotiU;
    mCagliotiV=fwhmCagliotiV;
    mCagliotiW=fwhmCagliotiW;
    mPseudoVoigtEta0=eta0;
    mPseudoVoigtEta1=eta1;
+   mScherrerP=scherrerP;
    mClockMaster.Click();
 }
 
@@ -193,9 +197,11 @@ REAL ReflectionProfilePseudoVoigt::GetFullProfileWidth(const REAL relativeIntens
    const int halfnb=nb/2;
    CrystVector_REAL x(nb);
    REAL n=5.0;
+   const REAL costheta=cos(center/2.0);
    REAL fwhm= mCagliotiW
              +mCagliotiV*tan(center/2.0)
-             +mCagliotiU*pow(tan(center/2.0),2);
+             +mCagliotiU*pow(tan(center/2.0),2)
+             +mScherrerP/(costheta*costheta);
    if(fwhm<=0) fwhm=1e-6;
    else fwhm=sqrt(fwhm);
    CrystVector_REAL prof;
@@ -248,6 +254,14 @@ void ReflectionProfilePseudoVoigt::InitParameters()
    }
    {
       RefinablePar tmp("W",&mCagliotiW,0,1./RAD2DEG/RAD2DEG,
+                        gpRefParTypeScattDataProfileWidth,
+                        REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
+      tmp.AssignClock(mClockMaster);
+      tmp.SetDerivStep(1e-9);
+      this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("P",&mScherrerP,-1./RAD2DEG/RAD2DEG,1./RAD2DEG/RAD2DEG,
                         gpRefParTypeScattDataProfileWidth,
                         REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
       tmp.AssignClock(mClockMaster);
@@ -338,6 +352,9 @@ void ReflectionProfilePseudoVoigt::XMLOutput(ostream &os,int indent)const
    this->GetPar(&mCagliotiW).XMLOutput(os,"W",indent);
    os <<endl;
 
+   this->GetPar(&mScherrerP).XMLOutput(os,"P",indent);
+   os <<endl;
+
    this->GetPar(&mPseudoVoigtEta0).XMLOutput(os,"Eta0",indent);
    os <<endl;
 
@@ -406,6 +423,11 @@ void ReflectionProfilePseudoVoigt::XMLInput(istream &is,const XMLCrystTag &tagg)
                if("W"==tag.GetAttributeValue(i))
                {
                   this->GetPar(&mCagliotiW).XMLInput(is,tag);
+                  break;
+               }
+               if("P"==tag.GetAttributeValue(i))
+               {
+                  this->GetPar(&mScherrerP).XMLInput(is,tag);
                   break;
                }
                if("Eta0"==tag.GetAttributeValue(i))

--- a/ObjCryst/ObjCryst/ReflectionProfile.h
+++ b/ObjCryst/ObjCryst/ReflectionProfile.h
@@ -111,7 +111,7 @@ class ReflectionProfilePseudoVoigt:public ReflectionProfile
       *
       * \param fwhmCagliotiW,fwhmCagliotiU,fwhmCagliotiV : these are the U,V and W
       * parameters in the Caglioti's law :
-      * \f$ fwhm^2= U \tan^2(\theta) + V \tan(\theta) +W \f$
+      * \f$ fwhm^2= U \tan^2(\theta) + V \tan(\theta) +W + \frac{P}{\cos^2\vartheta} \f$
       * if only W is given, the width is constant
       * \param eta0,eta1: these are the mixing parameters.
       */
@@ -119,7 +119,8 @@ class ReflectionProfilePseudoVoigt:public ReflectionProfile
                          const REAL fwhmCagliotiU=0,
                          const REAL fwhmCagliotiV=0,
                          const REAL eta0=0.5,
-                         const REAL eta1=0.);
+                         const REAL eta1=0.,
+                         const REAL scherrerP=0.);
       virtual REAL GetFullProfileWidth(const REAL relativeIntensity, const REAL xcenter,
                                        const REAL h, const REAL k, const REAL l);
       bool IsAnisotropic()const;
@@ -128,8 +129,8 @@ class ReflectionProfilePseudoVoigt:public ReflectionProfile
    private:
       /// Initialize parameters
       void InitParameters();
-      ///FWHM parameters, following Caglioti's law
-      REAL mCagliotiU,mCagliotiV,mCagliotiW;
+      ///FWHM parameters, following Caglioti's law and a Scherrer-like term
+      REAL mCagliotiU,mCagliotiV,mCagliotiW,mScherrerP;
       ///Pseudo-Voigt mixing parameter : eta=eta0 +2*theta*eta1
       /// eta=1 -> pure Lorentzian ; eta=0 -> pure Gaussian
       REAL mPseudoVoigtEta0,mPseudoVoigtEta1;


### PR DESCRIPTION
It already exists in the anisotropic pseudo-Voigt profile in objcryst. 

I added it to the isotropic profile because 

* the effect is isotropic
* isotropic pseudo-Voigt is the only profile currently exposed to pyobjcryst

This broadening model is very limited and the resulting `P` value converted to apparent crystallite size should be taken very qualitatively. 

It might still be useful to have this model to get a good fit, if you're sure observed peak broadening is coming from small crystallites, as the 2θ dependence is very different to existing per-phase Caglioti params U,V,W (which otherwise might be used to account for such effects empirically). 

All of this to say: I understand if this addition is deemed not sensible, but for me is has been useful in practice, so here it is. 