### PR TITLE
Use insertion-ordered vector for LSQNumObj refined object list

### DIFF
--- a/ObjCryst/RefinableObj/GlobalOptimObj.cpp
+++ b/ObjCryst/RefinableObj/GlobalOptimObj.cpp
@@ -1587,15 +1587,15 @@ void MonteCarloObj::RunParallelTempering(long &nbStep,const bool silent,
 
                #if 0
                // Report GoF values (Chi^2 / nbObs) values for all objects
-               for(map<RefinableObj*,unsigned int>::iterator pos=mLSQ.GetRefinedObjMap().begin();pos!=mLSQ.GetRefinedObjMap().end();++pos)
-                  if(pos->first->GetNbLSQFunction()>0)
+               for(auto& pos : mLSQ.GetRefinedObjMap())
+                  if(pos.first->GetNbLSQFunction()>0)
                   {
                      CrystVector_REAL tmp;
-                     tmp =pos->first->GetLSQCalc(pos->second);
-                     tmp-=pos->first->GetLSQObs (pos->second);
+                     tmp =pos.first->GetLSQCalc(pos.second);
+                     tmp-=pos.first->GetLSQObs (pos.second);
                      tmp*=tmp;
-                     tmp*=pos->first->GetLSQWeight(pos->second);
-                     cout<<pos->first->GetClassName()<<":"<<pos->first->GetName()<<": GoF="<<tmp.sum()/tmp.numElements();
+                     tmp*=pos.first->GetLSQWeight(pos.second);
+                     cout<<pos.first->GetClassName()<<":"<<pos.first->GetName()<<": GoF="<<tmp.sum()/tmp.numElements();
                   }
                cout<<endl;
                #endif
@@ -1606,15 +1606,15 @@ void MonteCarloObj::RunParallelTempering(long &nbStep,const bool silent,
                catch(const ObjCrystException &except){};
                #if 0
                // Report GoF values (Chi^2 / nbObs) values for all objects
-               for(map<RefinableObj*,unsigned int>::iterator pos=mLSQ.GetRefinedObjMap().begin();pos!=mLSQ.GetRefinedObjMap().end();++pos)
-                  if(pos->first->GetNbLSQFunction()>0)
+               for(auto& pos : mLSQ.GetRefinedObjMap())
+                  if(pos.first->GetNbLSQFunction()>0)
                   {
                      CrystVector_REAL tmp;
-                     tmp =pos->first->GetLSQCalc(pos->second);
-                     tmp-=pos->first->GetLSQObs (pos->second);
+                     tmp =pos.first->GetLSQCalc(pos.second);
+                     tmp-=pos.first->GetLSQObs (pos.second);
                      tmp*=tmp;
-                     tmp*=pos->first->GetLSQWeight(pos->second);
-                     cout<<pos->first->GetClassName()<<":"<<pos->first->GetName()<<": GoF="<<tmp.sum()/tmp.numElements();
+                     tmp*=pos.first->GetLSQWeight(pos.second);
+                     cout<<pos.first->GetClassName()<<":"<<pos.first->GetName()<<": GoF="<<tmp.sum()/tmp.numElements();
                   }
                cout<<endl;
                #endif
@@ -2298,8 +2298,8 @@ void MonteCarloObj::InitLSQ(const bool useFullPowderPatternProfile)
 
    if(!useFullPowderPatternProfile)
    {// Use LSQ function #1 for powder patterns (integrated patterns - faster !)
-      for(map<RefinableObj*,unsigned int>::iterator pos=mLSQ.GetRefinedObjMap().begin();pos!=mLSQ.GetRefinedObjMap().end();++pos)
-         if(pos->first->GetClassName()=="PowderPattern") pos->second=1;
+      for(auto& pos : mLSQ.GetRefinedObjMap())
+         if(pos.first->GetClassName()=="PowderPattern") pos.second=1;
    }
    // Only refine structural parameters (excepting parameters already fixed) and scale factor
    mLSQ.PrepareRefParList(true);

--- a/ObjCryst/RefinableObj/LSQNumObj.cpp
+++ b/ObjCryst/RefinableObj/LSQNumObj.cpp
@@ -812,34 +812,37 @@ void LSQNumObj::CalcChiSquare()const
 REAL LSQNumObj::ChiSquare()const{return mChiSq;};
 
 
-void RecursiveMapFunc(RefinableObj &obj,map<RefinableObj*,unsigned int> &themap, const unsigned int value)
+void RecursiveVecFunc(RefinableObj &obj, vector<pair<RefinableObj*,unsigned int>> &thevec, const unsigned int value)
 {
-   themap[&obj]=value;
+   bool found=false;
+   for(auto& p : thevec)
+      if(p.first==&obj) { p.second=value; found=true; break; }
+   if(!found) thevec.push_back({&obj,value});
    ObjRegistry<RefinableObj> *pObjReg=&(obj.GetSubObjRegistry());
    for(int i=0;i<pObjReg->GetNb();i++)
-      RecursiveMapFunc(pObjReg->GetObj(i),themap,value);
-   return;
+      RecursiveVecFunc(pObjReg->GetObj(i),thevec,value);
 }
 
 void LSQNumObj::SetRefinedObj(RefinableObj &obj, const unsigned int LSQFuncIndex, const bool init, const bool recursive)
-
 {
-   if(init)
+   if(init) mvRefinedObjMap.clear();
+   if(recursive) RecursiveVecFunc(obj,mvRefinedObjMap,LSQFuncIndex);
+   else
    {
-      mvRefinedObjMap.clear();
+      for(auto& p : mvRefinedObjMap)
+         if(p.first==&obj) { p.second=LSQFuncIndex; return; }
+      mvRefinedObjMap.push_back({&obj,LSQFuncIndex});
    }
-   if(recursive) RecursiveMapFunc(obj,mvRefinedObjMap,LSQFuncIndex);
-   else mvRefinedObjMap[&obj]=LSQFuncIndex;
 }
 
 //ObjRegistry<RefinableObj> &LSQNumObj::GetRefinedObjList(){return mRecursiveRefinedObjList;}
 
-const map<RefinableObj*,unsigned int>& LSQNumObj::GetRefinedObjMap() const
+const vector<pair<RefinableObj*,unsigned int>>& LSQNumObj::GetRefinedObjMap() const
 {
    return mvRefinedObjMap;
 }
 
-map<RefinableObj*,unsigned int>& LSQNumObj::GetRefinedObjMap()
+vector<pair<RefinableObj*,unsigned int>>& LSQNumObj::GetRefinedObjMap()
 {
    return mvRefinedObjMap;
 }
@@ -913,11 +916,11 @@ const std::map<pair<const RefinablePar*,const RefinablePar*>,REAL > & LSQNumObj:
 void LSQNumObj::PrepareRefParList(const bool copy_param)
 {
    mRefParList.ResetParList();
-   for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      VFN_DEBUG_MESSAGE("LSQNumObj::PrepareRefParList():"<<pos->first->GetName(),4);
+      VFN_DEBUG_MESSAGE("LSQNumObj::PrepareRefParList():"<<pos.first->GetName(),4);
       //mRecursiveRefinedObjList.GetObj(i).Print();
-      mRefParList.AddPar(*(pos->first),copy_param);
+      mRefParList.AddPar(*(pos.first),copy_param);
    }
    //mRefParList.Print();
    if(copy_param) mRefParList.SetDeleteRefParInDestructor(true);
@@ -928,10 +931,10 @@ const CrystVector_REAL& LSQNumObj::GetLSQCalc() const
 {
    const CrystVector_REAL *pV;
    long nb=0;
-   for(map<RefinableObj*,unsigned int>::const_iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      if(pos->first->GetNbLSQFunction()==0) continue;
-      pV=&(pos->first->GetLSQCalc(pos->second));
+      if(pos.first->GetNbLSQFunction()==0) continue;
+      pV=&(pos.first->GetLSQCalc(pos.second));
       const long n2 = pV->numElements();
       if((nb+n2)>mLSQCalc.numElements()) mLSQCalc.resizeAndPreserve(nb+pV->numElements());
       const REAL *p1=pV->data();
@@ -947,12 +950,12 @@ const CrystVector_REAL& LSQNumObj::GetLSQObs() const
 {
    const CrystVector_REAL *pV;
    long nb=0;
-   for(map<RefinableObj*,unsigned int>::const_iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      if(pos->first->GetNbLSQFunction()==0) continue;
-      pV=&(pos->first->GetLSQObs(pos->second));
+      if(pos.first->GetNbLSQFunction()==0) continue;
+      pV=&(pos.first->GetLSQObs(pos.second));
       const long n2 = pV->numElements();
-      mvRefinedObjLSQSize[pos->first]=n2;
+      mvRefinedObjLSQSize[pos.first]=n2;
       if((nb+n2)>mLSQObs.numElements()) mLSQObs.resizeAndPreserve(nb+pV->numElements());
       const REAL *p1=pV->data();
       REAL *p2=mLSQObs.data()+nb;
@@ -967,10 +970,10 @@ const CrystVector_REAL& LSQNumObj::GetLSQWeight() const
 {
    const CrystVector_REAL *pV;
    long nb=0;
-   for(map<RefinableObj*,unsigned int>::const_iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      if(pos->first->GetNbLSQFunction()==0) continue;
-      pV=&(pos->first->GetLSQWeight(pos->second));
+      if(pos.first->GetNbLSQFunction()==0) continue;
+      pV=&(pos.first->GetLSQWeight(pos.second));
       const long n2 = pV->numElements();
       if((nb+n2)>mLSQWeight.numElements()) mLSQWeight.resizeAndPreserve(nb+pV->numElements());
       const REAL *p1=pV->data();
@@ -986,10 +989,10 @@ const CrystVector_REAL& LSQNumObj::GetLSQDeriv(RefinablePar&par)
 {
    const CrystVector_REAL *pV;
    long nb=0;
-   for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      if(pos->first->GetNbLSQFunction()==0) continue;
-      pV=&(pos->first->GetLSQDeriv(pos->second,par));
+      if(pos.first->GetNbLSQFunction()==0) continue;
+      pV=&(pos.first->GetLSQDeriv(pos.second,par));
       const long n2 = pV->numElements();
       if((nb+n2)>mLSQDeriv.numElements()) mLSQDeriv.resizeAndPreserve(nb+pV->numElements());
       const REAL *p1=pV->data();
@@ -1009,13 +1012,13 @@ const std::map<RefinablePar*,CrystVector_REAL>& LSQNumObj::GetLSQ_FullDeriv()
       vPar.insert(&(mRefParList.GetParNotFixed(i)));
    mLSQ_FullDeriv.clear();
    unsigned long nb=0;// full length of derivative vector
-   for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
+   for(auto& pos : mvRefinedObjMap)
    {
-      if(pos->first->GetNbLSQFunction()==0) continue;
-      const unsigned long n2=mvRefinedObjLSQSize[pos->first];
+      if(pos.first->GetNbLSQFunction()==0) continue;
+      const unsigned long n2=mvRefinedObjLSQSize[pos.first];
       if(n2==0) continue;//this object does not have an LSQ function
 
-      const std::map<RefinablePar*,CrystVector_REAL> *pvV=&(pos->first->GetLSQ_FullDeriv(pos->second,vPar));
+      const std::map<RefinablePar*,CrystVector_REAL> *pvV=&(pos.first->GetLSQ_FullDeriv(pos.second,vPar));
       for(std::map<RefinablePar*,CrystVector_REAL>::const_iterator d=pvV->begin();d!=pvV->end();d++)
       {
          if(mLSQ_FullDeriv[d->first].size()==0) mLSQ_FullDeriv[d->first].resize(mLSQObs.size());
@@ -1023,7 +1026,7 @@ const std::map<RefinablePar*,CrystVector_REAL>& LSQNumObj::GetLSQ_FullDeriv()
          if(d->second.size()==0)
          {  //derivative can be null and then the vector missing
             // But we must still fill in zeros
-            cout<<__FILE__<<":"<<__LINE__<<":"<<pos->first->GetClassName()<<":"<<pos->first->GetName()<<":"<<d->first->GetName()<<" (all deriv=0)"<<endl;
+            cout<<__FILE__<<":"<<__LINE__<<":"<<pos.first->GetClassName()<<":"<<pos.first->GetName()<<":"<<d->first->GetName()<<" (all deriv=0)"<<endl;
             for(unsigned long j=0;j<n2;++j) *p2++ = 0;
          }
          else
@@ -1039,14 +1042,14 @@ const std::map<RefinablePar*,CrystVector_REAL>& LSQNumObj::GetLSQ_FullDeriv()
 
 void LSQNumObj::BeginOptimization(const bool allowApproximations, const bool enableRestraints)
 {
-   for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
-      pos->first->BeginOptimization(allowApproximations, enableRestraints);
+   for(auto& pos : mvRefinedObjMap)
+      pos.first->BeginOptimization(allowApproximations, enableRestraints);
 }
 
 void LSQNumObj::EndOptimization()
 {
-   for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
-      pos->first->EndOptimization();
+   for(auto& pos : mvRefinedObjMap)
+      pos.first->EndOptimization();
 }
 
 #ifdef __WX__CRYST__

--- a/ObjCryst/RefinableObj/LSQNumObj.h
+++ b/ObjCryst/RefinableObj/LSQNumObj.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <map>
 #include <list>
+#include <vector>
 
 namespace ObjCryst
 {
@@ -139,16 +140,16 @@ class LSQNumObj
       // of sub-objects before refinement (such as for removing certain types
       // of objects).
       //ObjRegistry<RefinableObj> &GetRefinedObjList();
-      /** Get the map of refined objects - this is a recursive list of all the objects
-      * that are taken into account for the refinement. The key is a pointer to the
-      * object and the value is the LSQ function index for that object.
+      /** Get the ordered list of refined objects.
+      * Objects are returned in first-insertion order. Each entry contains the
+      * object pointer and the LSQ function index for that object.
       */
-      const std::map<RefinableObj*,unsigned int>& GetRefinedObjMap() const;
-      /** Get the map of refined objects - this is a recursive list of all the objects
-      * that are taken into account for the refinement. The key is a pointer to the
-      * object and the value is the LSQ function index for that object.
+      const std::vector<std::pair<RefinableObj*,unsigned int>>& GetRefinedObjMap() const;
+      /** Get the ordered list of refined objects.
+      * Objects are returned in first-insertion order. Each entry contains the
+      * object pointer and the LSQ function index for that object.
       */
-      std::map<RefinableObj*,unsigned int>& GetRefinedObjMap();
+      std::vector<std::pair<RefinableObj*,unsigned int>>& GetRefinedObjMap();
       /** Access to the RefinableObj which is the compilation of all parameters
       * from the object supplied for optimization and its sub-objects.
       *
@@ -248,12 +249,10 @@ class LSQNumObj
       // The index of the LSQ function in the refined object (if there are several...)
       //unsigned int mLSQFuncIndex;
 
-      /** Map of the recursive list of the objects to be refined. The key is the pointer
-      * to the object and the value the LSQ function index
-      *
-      * Individual LSQ functions can be changed using GetRefinedObjMap().
+      /** Ordered list of objects to be refined, in SetRefinedObj() call order.
+      * Each entry is (object pointer, LSQ function index).
       */
-      std::map<RefinableObj*,unsigned int> mvRefinedObjMap;
+      std::vector<std::pair<RefinableObj*,unsigned int>> mvRefinedObjMap;
       /// Size of each object LSQ data. This is initialized in LSQNumObj::GetLSQObs()
       mutable std::map<RefinableObj*,unsigned int> mvRefinedObjLSQSize;
 


### PR DESCRIPTION
Replace `std::map<RefinableObj*>` with `std::vector<pair<RefinableObj*>>` in `mvRefinedObjMap`. The map iterated by pointer address (heap order), making the `~` deduplication suffixes appended to duplicate parameter names non-deterministic with respect to `SetRefinedObj()` call order.

With the vector, suffix count follows registration order, so the first phase registered gets bare names (`V`), the second gets `V~`, etc.

Alleviates https://github.com/vincefn/objcryst/issues/71. Doesn't fix it, because parameter names are still changed in-place, just in a more deterministic way. 