### PR TITLE
fix: lower default CellExplorer minimum unit cell length to 2.5 Å

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,11 @@ NEW FEATURES
   * Added an extensive non-GUI test suite (unit, integration and regression
     tests) under test/, covering the main ObjCryst++ API components
 
+IMPROVEMENTS
+  * Indexing (CellExplorer): lower the default minimum unit cell length from
+    4 Å to 2.5 Å, allowing correct indexing of compact structures such as
+    α-Fe, B, or ZRNCl (fixes issue #63)
+
 BUG FIXES
   * Fix CIF rhombohedral symmetry scoring mutating imported lattice
     (PR #70, @clemisch)

--- a/ObjCryst/ObjCryst/Indexing.cpp
+++ b/ObjCryst/ObjCryst/Indexing.cpp
@@ -1160,7 +1160,7 @@ float Score(const PeakList &dhkl, const RecUnitCell &rpar, const unsigned int nb
 
 CellExplorer::CellExplorer(const PeakList &dhkl, const CrystalSystem lattice, const unsigned int nbSpurious):
 mnpar(3),mpPeakList(&dhkl),
-mLengthMin(4),mLengthMax(25),
+mLengthMin(2.5),mLengthMax(25),
 mAngleMin(M_PI),mAngleMax(2*M_PI/3),
 mVolumeMin(0),mVolumeMax(1600),
 mZeroShiftMin(0),mZeroShiftMax(0),


### PR DESCRIPTION
Closes #63

## Summary

The default `mLengthMin` in `CellExplorer` was 4 Å, which is too large for a number of real compact structures:
- α-Fe: *a* ≈ 2.87 Å
- B (boron): *a* ≈ 2.9 Å
- ZRNCl: *a* ≈ 2.8 Å

According to the COD, there are ~430 orthorhombic structures with *a* between 2.5–3 Å, and ~75 below 2.5 Å.

## Change

Lower `mLengthMin` from **4 Å → 2.5 Å** in the `CellExplorer` constructor.