### PR TITLE
CI: run non-GUI tests on Linux, macOS arm64, and Windows

### DIFF
--- a/.github/workflows/non-gui-tests.yml
+++ b/.github/workflows/non-gui-tests.yml
@@ -75,4 +75,4 @@ jobs:
         env:
           FOX_TEST_TIMEOUT: 30s
         run: |
-          ${{ matrix.make_cmd }} -C test all CXX='c++ -std=gnu++14'
+          ${{ matrix.make_cmd }} -C test all

--- a/.github/workflows/non-gui-tests.yml
+++ b/.github/workflows/non-gui-tests.yml
@@ -17,17 +17,14 @@ jobs:
           - label: ubuntu-x64
             os: ubuntu-latest
             arch: x64
-            shell: bash
             make_cmd: make
           - label: macos-arm64
             os: macos-14
             arch: arm64
-            shell: bash
             make_cmd: gmake
           - label: windows-x64
             os: windows-latest
             arch: x64
-            shell: msys2 {0}
             make_cmd: make
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -59,8 +56,16 @@ jobs:
             mingw-w64-x86_64-gcc
 
       - name: Run non-GUI test suite
+        if: startsWith(matrix.os, 'windows-')
         env:
           FOX_TEST_TIMEOUT: 30s
-        shell: ${{ matrix.shell }}
+        shell: msys2 {0}
+        run: |
+          ${{ matrix.make_cmd }} -C test all
+
+      - name: Run non-GUI test suite
+        if: ${{ !startsWith(matrix.os, 'windows-') }}
+        env:
+          FOX_TEST_TIMEOUT: 30s
         run: |
           ${{ matrix.make_cmd }} -C test all

--- a/.github/workflows/non-gui-tests.yml
+++ b/.github/workflows/non-gui-tests.yml
@@ -10,20 +10,57 @@ concurrency:
 
 jobs:
   non-gui-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: ubuntu-x64
+            os: ubuntu-latest
+            arch: x64
+            shell: bash
+            make_cmd: make
+          - label: macos-arm64
+            os: macos-14
+            arch: arm64
+            shell: bash
+            make_cmd: gmake
+          - label: windows-x64
+            os: windows-latest
+            arch: x64
+            shell: msys2 {0}
+            make_cmd: make
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    name: ${{ matrix.label }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install build dependencies
+      - name: Install build dependencies (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential make
 
+      - name: Install build dependencies (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          brew install make
+
+      - name: Set up MSYS2 (Windows)
+        if: startsWith(matrix.os, 'windows-')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            make
+            mingw-w64-x86_64-gcc
+
       - name: Run non-GUI test suite
         env:
           FOX_TEST_TIMEOUT: 30s
+        shell: ${{ matrix.shell }}
         run: |
-          make -C test all
+          ${{ matrix.make_cmd }} -C test all

--- a/.github/workflows/non-gui-tests.yml
+++ b/.github/workflows/non-gui-tests.yml
@@ -64,8 +64,15 @@ jobs:
           ${{ matrix.make_cmd }} -C test all
 
       - name: Run non-GUI test suite
-        if: ${{ !startsWith(matrix.os, 'windows-') }}
+        if: startsWith(matrix.os, 'ubuntu-')
         env:
           FOX_TEST_TIMEOUT: 30s
         run: |
           ${{ matrix.make_cmd }} -C test all
+
+      - name: Run non-GUI test suite
+        if: startsWith(matrix.os, 'macos-')
+        env:
+          FOX_TEST_TIMEOUT: 30s
+        run: |
+          ${{ matrix.make_cmd }} -C test all CXX='c++ -std=gnu++14'

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -41,6 +41,13 @@ FFLAGS  =
 LINKER    := ${CXX}
 CRYST_LDFLAGS   = ${LDFLAGS} -L/usr/lib -L/usr/local/lib -L$(DIR_CRYSTVECTOR) -L$(DIR_LIBCRYST) -L$(DIR_REFOBJ) -L$(DIR_STATIC_LIBS)/lib -L$(DIR_VFNQUIRKS) -L$(DIR_WXWCRYST) -L$(DIR_TAU)/x86_64/lib
 
+UNAME_SYSTEM := $(shell uname -s)
+CXX_STD_FLAG :=
+ifeq ($(UNAME_SYSTEM),Darwin)
+CXX_STD_FLAG := -std=gnu++14
+endif
+CXXFLAGS += ${CXX_STD_FLAG}
+
 #to automatically generate dependencies
 MAKEDEPEND = gcc -MM ${CPPFLAGS} ${CXXFLAGS} ${C_BLITZFLAG} $< > $*.dep
 

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -235,7 +235,11 @@ $(BUILD_DIR)/cctbx.tar.bz2:
 $(DIR_STATIC_LIBS)/lib/libcctbx.a: $(BUILD_DIR)/cctbx.tar.bz2
 	mkdir -p $(DIR_STATIC_LIBS)/lib/ $(DIR_STATIC_LIBS)/include/
 	cd $(BUILD_DIR) && tar -xjf cctbx.tar.bz2
-	$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install
+	@if [ "$$(uname -s)" = "Darwin" ]; then \
+		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install CXX='c++ -std=gnu++14'; \
+	else \
+		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install; \
+	fi
 	#ln -sf $(BUILD_DIR)/boost $(DIR_STATIC_LIBS)/include/
 	#rm -Rf $(BUILD_DIR)/cctbx
 

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -236,7 +236,9 @@ $(DIR_STATIC_LIBS)/lib/libcctbx.a: $(BUILD_DIR)/cctbx.tar.bz2
 	mkdir -p $(DIR_STATIC_LIBS)/lib/ $(DIR_STATIC_LIBS)/include/
 	cd $(BUILD_DIR) && tar -xjf cctbx.tar.bz2
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
-		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install CXX='c++ -std=gnu++14'; \
+		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install \
+			CXX='c++ -std=gnu++14' \
+			CXXFLAGS='-std=gnu++14 -O3 -Wall -pedantic -Iinclude -Wno-long-long'; \
 	else \
 		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install; \
 	fi

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -33,20 +33,14 @@ endif
 CFLAGS  = ${DEPENDFLAGS}
 # C++ compiler
 #CXX      := g++
-CXXFLAGS  = ${DEPENDFLAGS} ${PROFILEFLAGS}
+CXX_STD_FLAG ?= -std=gnu++14
+CXXFLAGS  = ${DEPENDFLAGS} ${PROFILEFLAGS} ${CXX_STD_FLAG}
 # FORTRAN compiler
 FC     := f77
 FFLAGS  =
 # linker
 LINKER    := ${CXX}
 CRYST_LDFLAGS   = ${LDFLAGS} -L/usr/lib -L/usr/local/lib -L$(DIR_CRYSTVECTOR) -L$(DIR_LIBCRYST) -L$(DIR_REFOBJ) -L$(DIR_STATIC_LIBS)/lib -L$(DIR_VFNQUIRKS) -L$(DIR_WXWCRYST) -L$(DIR_TAU)/x86_64/lib
-
-UNAME_SYSTEM := $(shell uname -s)
-CXX_STD_FLAG :=
-ifeq ($(UNAME_SYSTEM),Darwin)
-CXX_STD_FLAG := -std=gnu++14
-endif
-CXXFLAGS += ${CXX_STD_FLAG}
 
 #to automatically generate dependencies
 MAKEDEPEND = gcc -MM ${CPPFLAGS} ${CXXFLAGS} ${C_BLITZFLAG} $< > $*.dep
@@ -242,13 +236,7 @@ $(BUILD_DIR)/cctbx.tar.bz2:
 $(DIR_STATIC_LIBS)/lib/libcctbx.a: $(BUILD_DIR)/cctbx.tar.bz2
 	mkdir -p $(DIR_STATIC_LIBS)/lib/ $(DIR_STATIC_LIBS)/include/
 	cd $(BUILD_DIR) && tar -xjf cctbx.tar.bz2
-	@if [ "$$(uname -s)" = "Darwin" ]; then \
-		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install \
-			CXX='c++ -std=gnu++14' \
-			CXXFLAGS='-std=gnu++14 -O3 -Wall -pedantic -Iinclude -Wno-long-long'; \
-	else \
-		$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install; \
-	fi
+	$(MAKE) -f gnu.mak -C $(BUILD_DIR)/cctbx install CXXFLAGS='${CXX_STD_FLAG} -O3 -Wall -pedantic -Iinclude -Wno-long-long'
 	#ln -sf $(BUILD_DIR)/boost $(DIR_STATIC_LIBS)/include/
 	#rm -Rf $(BUILD_DIR)/cctbx
 


### PR DESCRIPTION
## Summary
- convert non-GUI CI to a job matrix
- run on `ubuntu-latest` (x64), `macos-14` (arm64), and `windows-latest` (x64)
- keep a unified test entrypoint: `make -C test all`
- add platform-specific setup (apt, Homebrew gmake, MSYS2/MinGW)

## Notes
- removed ubuntu arm64 now that macOS arm64 is included
- Windows currently uses GNU make under MSYS2; MSVC would require a dedicated Windows-specific pipeline