### PR TITLE
Fix #35 and #37: refinement guards + wxWidgets 3.2.10 + FFTW 3.3.11

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,12 +11,17 @@ IMPROVEMENTS
     α-Fe, B, or ZRNCl (fixes issue #63)
 
 BUG FIXES
+  * Fix MonteCarlo refinement actions starting with no attached optimized object
+    (#35)
+  * Disable Le Bail + Fit Profile entry points when there is no observed powder
+    data or no PowderPatternDiffraction phase (#37)
   * Fix CIF rhombohedral symmetry scoring mutating imported lattice
     (PR #70, @clemisch)
   * Add per-phase sample-detector displacement ratio support with flat detector
     geometry in powder diffraction (PR #73, @clemisch)
   * Recompute PolarizationCorr when the linear polarization rate changes,
     using a dedicated Radiation clock (related to pyobjcryst issue #38)
+  * Bump bundled wxWidgets to 3.2.10 and FFTW to 3.3.11 in the makefiles
 
 #### 2024.1 (August 2024)
 NEW FEATURES

--- a/Fox/gnu.mak
+++ b/Fox/gnu.mak
@@ -34,7 +34,7 @@ clean: tidy
 tidy:
 	$(MAKE) -f gnu.mak -C src tidy
 	$(MAKE) -f gnu.mak -C ${BUILD_DIR}/ObjCryst tidy
-	${RM} -Rf ${BUILD_DIR}/fftw-3.3.4 ${BUILD_DIR}/newmat ${BUILD_DIR}/wxWidgets-3.1.6
+	${RM} -Rf ${BUILD_DIR}/fftw-3.3.11 ${BUILD_DIR}/newmat ${BUILD_DIR}/wxWidgets-3.1.6
 
 #install Fox in /usr/local/bin
 install:

--- a/Fox/macosx.mak
+++ b/Fox/macosx.mak
@@ -34,13 +34,13 @@ endif
 libfftw: ../static-libs/lib/libfftw3f.a
 
 
-../wxWidgets-3.2.5.tar.bz2:
-	cd .. && $(DOWNLOAD_COMMAND)  https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5.tar.bz2
+../wxWidgets-3.2.10.tar.bz2:
+	cd .. && $(DOWNLOAD_COMMAND)  https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.10/wxWidgets-3.2.10.tar.bz2
 
-../static-libs/bin/wx-config: ../wxWidgets-3.2.5.tar.bz2
-	cd .. && tar -xjf wxWidgets-3.2.5.tar.bz2
-	cd ../wxWidgets-3.2.5 && MACOSX_DEPLOYMENT_TARGET=11.0 ./configure --with-opengl --disable-debug --disable-webviewwebkit --enable-optimise --disable-shared  --enable-monolithic --disable-mediactrl --without-libtiff --enable-cxx11 --enable-universal_binary=x86_64,arm64 --prefix=$(PWD)/../static-libs && make -j4 install
-	rm -Rf ../wxWidgets-3.2.5
+../static-libs/bin/wx-config: ../wxWidgets-3.2.10.tar.bz2
+	cd .. && tar -xjf wxWidgets-3.2.10.tar.bz2
+	cd ../wxWidgets-3.2.10 && MACOSX_DEPLOYMENT_TARGET=11.0 ./configure --with-opengl --disable-debug --disable-webviewwebkit --enable-optimise --disable-shared  --enable-monolithic --disable-mediactrl --without-libtiff --enable-cxx11 --enable-universal_binary=x86_64,arm64 --prefix=$(PWD)/../static-libs && make -j4 install
+	rm -Rf ../wxWidgets-3.2.10
 
 libwx: ../static-libs/bin/wx-config
 

--- a/Fox/macosx.mak
+++ b/Fox/macosx.mak
@@ -22,12 +22,12 @@ endif
 ../newmat: ../newmat.tar.bz2
 	cd .. && tar -xjf newmat.tar.bz2
 
-../fftw-3.3.10.tar.gz:
-	cd .. &&  curl -O http://fftw.org/fftw-3.3.10.tar.gz
+../fftw-3.3.11.tar.gz:
+	cd .. &&  curl -O http://fftw.org/fftw-3.3.11.tar.gz
 
-../static-libs/lib/libfftw3f.a: ../fftw-3.3.10.tar.gz
+../static-libs/lib/libfftw3f.a: ../fftw-3.3.11.tar.gz
 	rm -f $(PWD)/../static-libs/lib/*fftw*
-	cd .. && tar -xzf fftw-3.3.10.tar.gz && mv fftw-3.3.10 fftw
+	cd .. && tar -xzf fftw-3.3.11.tar.gz && mv fftw-3.3.11 fftw
 	cd ../fftw && MACOSX_DEPLOYMENT_TARGET=11.0 ./configure --enable-single --prefix $(PWD)/../static-libs CFLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=11.0" && MACOSX_DEPLOYMENT_TARGET=11.0 make clean && MACOSX_DEPLOYMENT_TARGET=11.0 make -j4 install
 	rm -Rf ../fftw
 

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -211,13 +211,13 @@ else
 libfreeglut=
 endif
 
-$(BUILD_DIR)/wxWidgets-3.2.5.tar.bz2:
-	cd $(BUILD_DIR) && $(DOWNLOAD_COMMAND) https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5.tar.bz2
+$(BUILD_DIR)/wxWidgets-3.2.10.tar.bz2:
+	cd $(BUILD_DIR) && $(DOWNLOAD_COMMAND) https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.10/wxWidgets-3.2.10.tar.bz2
 
-$(BUILD_DIR)/static-libs/include/wx-3.2/wx/wx.h: $(BUILD_DIR)/wxWidgets-3.2.5.tar.bz2
-	cd $(BUILD_DIR) && rm -Rf wxWidgets-3.2.5 && tar -xjf wxWidgets-3.2.5.tar.bz2
-	cd $(BUILD_DIR)/wxWidgets-3.2.5 && ./configure --with-gtk --with-opengl --disable-glcanvasegl --prefix=$(BUILD_DIR)/static-libs --enable-unicode  --enable-optimise --disable-shared --x-includes=/usr/X11R6/include/ && $(MAKE) install
-	rm -Rf $(BUILD_DIR)/wxWidgets-3.2.5
+$(BUILD_DIR)/static-libs/include/wx-3.2/wx/wx.h: $(BUILD_DIR)/wxWidgets-3.2.10.tar.bz2
+	cd $(BUILD_DIR) && rm -Rf wxWidgets-3.2.10 && tar -xjf wxWidgets-3.2.10.tar.bz2
+	cd $(BUILD_DIR)/wxWidgets-3.2.10 && ./configure --with-gtk --with-opengl --disable-glcanvasegl --prefix=$(BUILD_DIR)/static-libs --enable-unicode  --enable-optimise --disable-shared --x-includes=/usr/X11R6/include/ && $(MAKE) install
+	rm -Rf $(BUILD_DIR)/wxWidgets-3.2.10
 
 ifneq ($(wxcryst),0)
 ifneq ($(shared-wxgtk),1)

--- a/ObjCryst/rules-gnu.mak
+++ b/ObjCryst/rules-gnu.mak
@@ -246,13 +246,13 @@ else
 libcctbx=
 endif
 
-$(BUILD_DIR)/fftw-3.3.10.tar.gz:
-	cd $(BUILD_DIR) && $(DOWNLOAD_COMMAND) http://fftw.org/fftw-3.3.10.tar.gz
+$(BUILD_DIR)/fftw-3.3.11.tar.gz:
+	cd $(BUILD_DIR) && $(DOWNLOAD_COMMAND) http://fftw.org/fftw-3.3.11.tar.gz
 
-$(DIR_STATIC_LIBS)/lib/libfftw3f.a: $(BUILD_DIR)/fftw-3.3.10.tar.gz
-	cd $(BUILD_DIR) && tar -xzf fftw-3.3.10.tar.gz
-	cd $(BUILD_DIR)/fftw-3.3.10 && ./configure --enable-single --prefix $(DIR_STATIC_LIBS) && $(MAKE) install
-	rm -Rf $(BUILD_DIR)/fftw-3.3.10
+$(DIR_STATIC_LIBS)/lib/libfftw3f.a: $(BUILD_DIR)/fftw-3.3.11.tar.gz
+	cd $(BUILD_DIR) && tar -xzf fftw-3.3.11.tar.gz
+	cd $(BUILD_DIR)/fftw-3.3.11 && ./configure --enable-single --prefix $(DIR_STATIC_LIBS) && $(MAKE) install
+	rm -Rf $(BUILD_DIR)/fftw-3.3.11
 
 ifneq ($(fftw),0)
 ifneq ($(shared-fftw),1)

--- a/ObjCryst/wxCryst/wxGlobalOptimObj.cpp
+++ b/ObjCryst/wxCryst/wxGlobalOptimObj.cpp
@@ -50,6 +50,20 @@
 
 namespace ObjCryst
 {
+namespace
+{
+bool EnsureHasOptimizedObject(wxWindow *parent, const OptimizationObj &optimObj)
+{
+   if(optimObj.GetRefinedObjList().GetNb()>0) return true;
+   wxMessageDialog noObject(parent,
+                            _T("Cannot launch refinement: no object is attached to this Monte-Carlo optimization.\n")
+                            _T("Use 'Optimized Objects -> Add object to optimize' first."),
+                            _T("No object to optimize"),
+                            wxOK|wxICON_EXCLAMATION);
+   noObject.ShowModal();
+   return false;
+}
+}
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -507,6 +521,11 @@ void WXMonteCarloObj::OnRunOptimization(wxCommandEvent & event)
 {
    VFN_DEBUG_ENTRY("WXMonteCarloObj::OnRunOptimization()",6)
    WXCrystValidateAllUserInput();
+   if(false==EnsureHasOptimizedObject(this,this->GetOptimizationObj()))
+   {
+      VFN_DEBUG_EXIT("WXMonteCarloObj::OnRunOptimization()",6)
+      return;
+   }
    if(true==this->GetOptimizationObj().IsOptimizing())
    {
       wxMessageDialog dumbUser(this,_T("The optimization is already running !"),_T("Huh ?"),
@@ -571,6 +590,7 @@ void WXMonteCarloObj::OnRunOptimization(wxCommandEvent & event)
 void WXMonteCarloObj::OnLSQRefine(wxCommandEvent &event)
 {
    WXCrystValidateAllUserInput();
+   if(false==EnsureHasOptimizedObject(this,this->GetOptimizationObj())) return;
    if(true==this->GetOptimizationObj().IsOptimizing())
    {
       wxMessageDialog dumbUser(this,_T("An optimization is already running !"),_T("Huh ?"),

--- a/ObjCryst/wxCryst/wxPowderPattern.cpp
+++ b/ObjCryst/wxCryst/wxPowderPattern.cpp
@@ -3277,9 +3277,32 @@ void WXPowderPatternGraph::OnChangeScale(wxCommandEvent& event)
 
 void WXPowderPatternGraph::OnLeBail(wxCommandEvent& event)
 {
+   PowderPattern &pattern=this->GetWXPowderPattern().GetPowderPattern();
+   if(pattern.GetNbPoint()==0)
+   {
+      wxMessageDialog noData(this,
+                             _T("Cannot run Le Bail: the powder pattern has no observed data.\n")
+                             _T("Please import observed data first."),
+                             _T("No observed data"),wxOK|wxICON_EXCLAMATION);
+      noData.ShowModal();
+      return;
+   }
+   bool hasDiff=false;
+   for(unsigned int i=0;i<pattern.GetNbPowderPatternComponent();++i)
+      if(pattern.GetPowderPatternComponent(i).GetClassName()==string("PowderPatternDiffraction"))
+      { hasDiff=true; break; }
+   if(!hasDiff)
+   {
+      wxMessageDialog noPhase(this,
+                              _T("Cannot run Le Bail: the powder pattern has no crystalline phase.\n")
+                              _T("Please add a PowderPatternDiffraction component first."),
+                              _T("No crystalline phase"),wxOK|wxICON_EXCLAMATION);
+      noPhase.ShowModal();
+      return;
+   }
    wxFrame *pFrame=new wxFrame(this,-1,_T("Profile Fitting"));
    WXProfileFitting *pFit;
-   pFit=new WXProfileFitting(pFrame,&(this->GetWXPowderPattern().GetPowderPattern()));
+   pFit=new WXProfileFitting(pFrame,&pattern);
    pFrame->Show(true);
 }
 
@@ -5032,6 +5055,16 @@ void WXPowderPatternDiffraction::OnLeBail(wxCommandEvent &event)
    {
       mpPowderPatternDiffraction->SetExtractionMode(false);
       mpPowderPatternDiffraction->GetParentPowderPattern().UpdateDisplay();
+      return;
+   }
+   if(mpPowderPatternDiffraction->GetParentPowderPattern().GetNbPoint()==0)
+   {
+      wxMessageDialog noData(this,
+                             _T("Cannot run Le Bail: the powder pattern has no observed data.\n")
+                             _T("Please import observed data first."),
+                             _T("No observed data"),wxOK|wxICON_EXCLAMATION);
+      noData.ShowModal();
+      if(event.GetId()==ID_POWDERDIFF_PROFILEFITTINGMODE) mpProfileFittingMode->SetValue(false);
       return;
    }
    mpPowderPatternDiffraction->SetExtractionMode(true,false);

--- a/ObjCryst/wxCryst/wxPowderPattern.cpp
+++ b/ObjCryst/wxCryst/wxPowderPattern.cpp
@@ -1043,15 +1043,38 @@ void WXPowderPattern::OnMenuAddExclude(wxCommandEvent & WXUNUSED(event))
 
 void WXPowderPattern::OnMenuLeBail(wxCommandEvent& event)
 {
+   PowderPattern &pattern=this->GetPowderPattern();
+   if(pattern.GetNbPoint()==0)
+   {
+      wxMessageDialog noData(this,
+                             _T("Cannot run Le Bail: the powder pattern has no observed data.\n")
+                             _T("Please import observed data first."),
+                             _T("No observed data"),wxOK|wxICON_EXCLAMATION);
+      noData.ShowModal();
+      return;
+   }
+   bool hasDiff=false;
+   for(unsigned int i=0;i<pattern.GetNbPowderPatternComponent();++i)
+      if(pattern.GetPowderPatternComponent(i).GetClassName()==string("PowderPatternDiffraction"))
+      { hasDiff=true; break; }
+   if(!hasDiff)
+   {
+      wxMessageDialog noPhase(this,
+                              _T("Cannot run Le Bail: the powder pattern has no crystalline phase.\n")
+                              _T("Please add a PowderPatternDiffraction component first."),
+                              _T("No crystalline phase"),wxOK|wxICON_EXCLAMATION);
+      noPhase.ShowModal();
+      return;
+   }
    #if 0
    wxFrame *pFrame=new wxFrame(this,-1,_T("Profile Fitting"));
    WXProfileFitting *pFit;
-   pFit=new WXProfileFitting(pFrame,&(this->GetPowderPattern()));
+   pFit=new WXProfileFitting(pFrame,&pattern);
    pFrame->Show(true);
    #else
    cout<<"Beginning refinement"<<endl;
    LSQNumObj lsq;
-   lsq.SetRefinedObj(this->GetPowderPattern(),0,true,true);
+   lsq.SetRefinedObj(pattern,0,true,true);
    lsq.PrepareRefParList(true);
    lsq.SetParIsFixed(gpRefParTypeObjCryst,true);
    lsq.SetParIsFixed(gpRefParTypeScatt,false);


### PR DESCRIPTION
Fixes #35 and #37.

---

### Fix #35 — Guard against launching refinement on an empty `MonteCarloObj`

Clicking any of the three refinement actions (Single Run, Multiple Runs, Least Squares Fit) on a freshly created `MonteCarloObj` that has no attached objects caused a crash/hang.

Added `EnsureHasOptimizedObject()` in `wxGlobalOptimObj.cpp`, called from both `WXMonteCarloObj::OnRunOptimization` and `WXMonteCarloObj::OnLSQRefine`. If no object is attached a clear dialog is shown directing the user to add one first.

---

### Fix #37 — Guard Le Bail entry points against missing observed data / missing crystalline phase

Clicking the Le Bail / profile-fitting entries crashed when the powder pattern had no observed data loaded or no crystalline phase.

- `WXPowderPattern::OnMenuLeBail`: now checks both no-observed-data and no-`PowderPatternDiffraction` before running.
- `WXPowderPatternDiffraction::OnLeBail`: checks `GetNbPoint()==0` before opening the dialog; also resets the Profile Fitting checkbox if triggered from it.
- `WXPowderPatternGraph::OnLeBail`: checks both no-observed-data and no-`PowderPatternDiffraction`.

Each path now shows a descriptive dialog and returns early instead of crashing.

---

### Dependency bumps
- wxWidgets **3.2.5 → 3.2.10** in `Fox/macosx.mak` and `ObjCryst/rules-gnu.mak`
- FFTW **3.3.10 → 3.3.11** in `Fox/macosx.mak` and `ObjCryst/rules-gnu.mak`
- Updated the stale FFTW cleanup path in `Fox/gnu.mak` to `3.3.11`