### PR TITLE
Fix single-crystal simulate crashes

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,6 +11,9 @@ IMPROVEMENTS
     α-Fe, B, or ZRNCl (fixes issue #63)
 
 BUG FIXES
+  * Fix single-crystal simulation crashing when showing simulated data or when
+    grouped reflection modes are enabled, and add regression tests for the
+    ungrouped and grouped simulate workflows
   * Fix MonteCarlo refinement actions starting with no attached optimized object
     (#35)
   * Disable Le Bail + Fit Profile entry points when there is no observed powder

--- a/ObjCryst/ObjCryst/DiffractionDataSingleCrystal.cpp
+++ b/ObjCryst/ObjCryst/DiffractionDataSingleCrystal.cpp
@@ -214,12 +214,37 @@ void DiffractionDataSingleCrystal::SetWeight(const CrystVector_REAL& weight)
 void DiffractionDataSingleCrystal::SetIobsToIcalc()
 {
    VFN_DEBUG_MESSAGE("DiffractionDataSingleCrystal::SetIobsToIcalc()",5)
-   mObsIntensity=this->GetIcalc();
+   this->GetFhklCalcSq();
+   mObsIntensity=mFhklCalcSq;
+   mObsIntensity*=mScaleFactor;
    mObsSigma.resize(mNbRefl);
    mWeight.resize(mNbRefl);
    mWeight=1;
-   mObsSigma=0;
+   mObsSigma=1;
    mHasObservedData=true;
+   if(1==mGroupOption.GetChoice())
+   {
+     mClockPrepareTwinningCorr.Reset();
+   }
+   else
+     if(2==mGroupOption.GetChoice())
+     {
+        // Simulated reflections have no imported user grouping metadata.
+        // Keep the "sum according to user data" mode safe by treating each
+        // generated reflection as its own group.
+        mNbGroup=mNbRefl;
+        mGroupIndex.resize(mNbGroup);
+        mGroupIobs.resize(mNbGroup);
+        mGroupSigma.resize(mNbGroup);
+        mGroupWeight.resize(mNbGroup);
+        for(long i=0;i<mNbGroup;i++)
+        {
+           mGroupIndex(i)=i+1;
+           mGroupIobs(i)=mObsIntensity(i);
+           mGroupSigma(i)=mObsSigma(i);
+           mGroupWeight(i)=mWeight(i);
+        }
+     }
    // Keep a copy as squared F(hkl), to enable fourier maps
    // :TODO: stop using mObsIntensity and just keep mFhklObsSq ?
    mFhklObsSq=mObsIntensity;

--- a/ObjCryst/wxCryst/wxDiffractionSingleCrystal.cpp
+++ b/ObjCryst/wxCryst/wxDiffractionSingleCrystal.cpp
@@ -334,6 +334,7 @@ void WXDiffractionSingleCrystal::OnMenuSimulate(wxCommandEvent & WXUNUSED(event)
    const int choice=dialog.GetSelection();
    if(0==choice) mpData->GenHKLFullSpace(theta*DEG2RAD,false);
    else mpData->GenHKLFullSpace(theta*DEG2RAD,true);
+   mpData->SetIobsToIcalc();
 }
 void WXDiffractionSingleCrystal::OnMenuImport(wxCommandEvent & event)
 {

--- a/test/unit/api_scattering.cpp
+++ b/test/unit/api_scattering.cpp
@@ -101,51 +101,15 @@ void TestSingleCrystalGroundTruthNeutron()
                                                "../../test/data/ground_truth/singlecrystal_neutron_pbso4.txt", 1e-2f, 1e-5f);
 }
 
-// Regression test for the crash in WXDiffractionSingleCrystal::OnMenuShowGraph
-// when called after OnMenuSimulate.
+// Regression helper for the single-crystal simulate workflow used by
+// WXDiffractionSingleCrystal::OnMenuSimulate.
 //
-// Before the fix, OnMenuSimulate called only GenHKLFullSpace(), which generated
-// reflections and populated Icalc, but left Iobs empty.  OnMenuShowGraph then
-// called CrystUpdate(), which iterated over Icalc.numElements() entries and
-// read Iobs(i) at each step — a fatal out-of-bounds access.
-//
-// The fix adds SetIobsToIcalc() at the end of OnMenuSimulate so that Iobs is
-// initialised to the simulated intensities.  This test covers that full
-// sequence and asserts that the resulting Iobs and Icalc arrays have the same
-// size, which is the invariant required for safe graph display.
-void TestSingleCrystalSimulateThenShowGraph()
-{
-   using namespace ObjCryst;
-   Crystal c = MakePbso4Crystal();
-   DiffractionDataSingleCrystal sc(c, false);
-   sc.SetRadiationType(RAD_XRAY);
-   sc.SetWavelength(1.54056);
-
-   // Reproduce the OnMenuSimulate action: generate reflections up to 50 degrees
-   // theta (all reflections, no Friedel merging).
-   sc.GenHKLFullSpace(50.0 * DEG2RAD, false);
-   Check(sc.GetNbRefl() > 0, "GenHKLFullSpace produced no reflections");
-
-   // Fixed OnMenuSimulate: set Iobs from the freshly calculated intensities.
-   sc.SetIobsToIcalc();
-
-   // GetIcalc() triggers CalcIcalc() and returns a non-empty array.
-   const long nbCalc = sc.GetIcalc().numElements();
-   Check(nbCalc > 0, "GetIcalc() is empty after GenHKLFullSpace + SetIobsToIcalc");
-
-   // GetIobs() must now have the same size so that the graph-display loop in
-   // CrystUpdate (which iterates nb = Icalc.numElements() times and reads both
-   // arrays) does not go out of bounds.
-   const long nbObs = sc.GetIobs().numElements();
-   Check(nbObs == nbCalc,
-         "GetIobs() size differs from GetIcalc() after simulate workflow");
-
-   // Also verify the values are consistent: Iobs should equal Icalc after
-   // SetIobsToIcalc, so a direct comparison of a few entries should hold.
-   Check(sc.GetIobs()(0) == sc.GetIcalc()(0),
-         "Iobs(0) should equal Icalc(0) immediately after SetIobsToIcalc");
-}
-
+// This covers the exact state that matters for the old Show Graph crash:
+// generate HKLs, populate simulated observations via SetIobsToIcalc(), then
+// verify that observed and calculated intensities stay identical and that the
+// residual statistics collapse to zero. Using groupChoice=0 exercises the same
+// ungrouped path as the former TestSingleCrystalSimulateThenShowGraph, so that
+// dedicated test was fully redundant.
 void TestSingleCrystalSimulateGrouped(const int groupChoice, const char* const label)
 {
    using namespace ObjCryst;
@@ -163,13 +127,23 @@ void TestSingleCrystalSimulateGrouped(const int groupChoice, const char* const l
    Check(nbCalc > 0, "GetIcalc() is empty after grouped simulation");
    Check(sc.GetIobs().numElements() == nbCalc,
          "GetIobs() size differs from GetIcalc() after grouped simulation");
+   for(long i = 0; i < nbCalc; ++i)
+   {
+      CheckNearAbsRel(sc.GetIobs()(i), sc.GetIcalc()(i), 1e-6, 1e-8,
+                      std::string(label) + ": Iobs should match Icalc after SetIobsToIcalc");
+   }
 
    const REAL chi2 = sc.GetChi2();
    const REAL r = sc.GetR();
    const REAL rw = sc.GetRw();
-   Check(std::isfinite(chi2), (std::string(label) + ": Chi2 should be finite").c_str());
-   Check(std::isfinite(r), (std::string(label) + ": R should be finite").c_str());
-   Check(std::isfinite(rw), (std::string(label) + ": Rw should be finite").c_str());
+   CheckNearAbsRel(chi2, 0, 1e-5, 1e-7, std::string(label) + ": Chi2 should be zero");
+   CheckNearAbsRel(r, 0, 1e-5, 1e-7, std::string(label) + ": R should be zero");
+   CheckNearAbsRel(rw, 0, 1e-5, 1e-7, std::string(label) + ": Rw should be zero");
+}
+
+void TestSingleCrystalSimulateUngrouped()
+{
+   TestSingleCrystalSimulateGrouped(0, "ungrouped simulation");
 }
 
 void TestSingleCrystalSimulateGroupedEquallySpaced()
@@ -199,7 +173,7 @@ int main(int argc, char* argv[])
    else if(testName == "diffractiondata-observed") TestDiffractionDataSingleCrystalObservedData();
    else if(testName == "singlecrystal-groundtruth-xray") TestSingleCrystalGroundTruthXray();
    else if(testName == "singlecrystal-groundtruth-neutron") TestSingleCrystalGroundTruthNeutron();
-   else if(testName == "singlecrystal-simulate-show-graph") TestSingleCrystalSimulateThenShowGraph();
+   else if(testName == "singlecrystal-simulate-ungrouped") TestSingleCrystalSimulateUngrouped();
    else if(testName == "singlecrystal-simulate-grouped-equal") TestSingleCrystalSimulateGroupedEquallySpaced();
    else if(testName == "singlecrystal-simulate-grouped-user") TestSingleCrystalSimulateGroupedUserData();
    else

--- a/test/unit/api_scattering.cpp
+++ b/test/unit/api_scattering.cpp
@@ -104,15 +104,15 @@ void TestSingleCrystalGroundTruthNeutron()
 // Regression test for the crash in WXDiffractionSingleCrystal::OnMenuShowGraph
 // when called after OnMenuSimulate.
 //
-// OnMenuSimulate calls GenHKLFullSpace(), which generates reflections and
-// populates Icalc, but leaves Iobs empty.  OnMenuShowGraph then calls
-// CrystUpdate(), which iterates over Icalc.numElements() entries and reads
-// Iobs(i) at each step — a fatal out-of-bounds access when Iobs is empty.
+// Before the fix, OnMenuSimulate called only GenHKLFullSpace(), which generated
+// reflections and populated Icalc, but left Iobs empty.  OnMenuShowGraph then
+// called CrystUpdate(), which iterated over Icalc.numElements() entries and
+// read Iobs(i) at each step — a fatal out-of-bounds access.
 //
-// The fix is for GenHKLFullSpace (or a post-simulate step) to initialise Iobs
-// to a consistent size.  This test captures that contract: after
-// GenHKLFullSpace, GetIcalc() and GetIobs() must have the same number of
-// elements so that graph-display code can safely read both arrays in lockstep.
+// The fix adds SetIobsToIcalc() at the end of OnMenuSimulate so that Iobs is
+// initialised to the simulated intensities.  This test covers that full
+// sequence and asserts that the resulting Iobs and Icalc arrays have the same
+// size, which is the invariant required for safe graph display.
 void TestSingleCrystalSimulateThenShowGraph()
 {
    using namespace ObjCryst;
@@ -122,22 +122,28 @@ void TestSingleCrystalSimulateThenShowGraph()
    sc.SetWavelength(1.54056);
 
    // Reproduce the OnMenuSimulate action: generate reflections up to 50 degrees
-   // theta (all reflections, no Friedel merging), then check that there are
-   // reflections (otherwise the test is vacuous).
+   // theta (all reflections, no Friedel merging).
    sc.GenHKLFullSpace(50.0 * DEG2RAD, false);
    Check(sc.GetNbRefl() > 0, "GenHKLFullSpace produced no reflections");
 
+   // Fixed OnMenuSimulate: set Iobs from the freshly calculated intensities.
+   sc.SetIobsToIcalc();
+
    // GetIcalc() triggers CalcIcalc() and returns a non-empty array.
    const long nbCalc = sc.GetIcalc().numElements();
-   Check(nbCalc > 0, "GetIcalc() is empty after GenHKLFullSpace");
+   Check(nbCalc > 0, "GetIcalc() is empty after GenHKLFullSpace + SetIobsToIcalc");
 
-   // GetIobs() must return an array of the same size so that code iterating
-   // over both in lockstep (as CrystUpdate does when building the graph) does
-   // not read out of bounds.
+   // GetIobs() must now have the same size so that the graph-display loop in
+   // CrystUpdate (which iterates nb = Icalc.numElements() times and reads both
+   // arrays) does not go out of bounds.
    const long nbObs = sc.GetIobs().numElements();
    Check(nbObs == nbCalc,
-         "GetIobs() size differs from GetIcalc() size after GenHKLFullSpace: "
-         "crash would occur in WXDiffractionSingleCrystal::CrystUpdate");
+         "GetIobs() size differs from GetIcalc() after simulate workflow");
+
+   // Also verify the values are consistent: Iobs should equal Icalc after
+   // SetIobsToIcalc, so a direct comparison of a few entries should hold.
+   Check(sc.GetIobs()(0) == sc.GetIcalc()(0),
+         "Iobs(0) should equal Icalc(0) immediately after SetIobsToIcalc");
 }
 
 } // namespace

--- a/test/unit/api_scattering.cpp
+++ b/test/unit/api_scattering.cpp
@@ -146,6 +146,42 @@ void TestSingleCrystalSimulateThenShowGraph()
          "Iobs(0) should equal Icalc(0) immediately after SetIobsToIcalc");
 }
 
+void TestSingleCrystalSimulateGrouped(const int groupChoice, const char* const label)
+{
+   using namespace ObjCryst;
+   Crystal c = MakePbso4Crystal();
+   DiffractionDataSingleCrystal sc(c, false);
+   sc.SetRadiationType(RAD_XRAY);
+   sc.SetWavelength(1.54056);
+   sc.GetOption("Group Reflections").SetChoice(groupChoice);
+
+   sc.GenHKLFullSpace(50.0 * DEG2RAD, false);
+   Check(sc.GetNbRefl() > 0, "GenHKLFullSpace produced no reflections");
+   sc.SetIobsToIcalc();
+
+   const long nbCalc = sc.GetIcalc().numElements();
+   Check(nbCalc > 0, "GetIcalc() is empty after grouped simulation");
+   Check(sc.GetIobs().numElements() == nbCalc,
+         "GetIobs() size differs from GetIcalc() after grouped simulation");
+
+   const REAL chi2 = sc.GetChi2();
+   const REAL r = sc.GetR();
+   const REAL rw = sc.GetRw();
+   Check(std::isfinite(chi2), (std::string(label) + ": Chi2 should be finite").c_str());
+   Check(std::isfinite(r), (std::string(label) + ": R should be finite").c_str());
+   Check(std::isfinite(rw), (std::string(label) + ": Rw should be finite").c_str());
+}
+
+void TestSingleCrystalSimulateGroupedEquallySpaced()
+{
+   TestSingleCrystalSimulateGrouped(1, "equally-spaced grouping");
+}
+
+void TestSingleCrystalSimulateGroupedUserData()
+{
+   TestSingleCrystalSimulateGrouped(2, "user-data grouping");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -164,6 +200,8 @@ int main(int argc, char* argv[])
    else if(testName == "singlecrystal-groundtruth-xray") TestSingleCrystalGroundTruthXray();
    else if(testName == "singlecrystal-groundtruth-neutron") TestSingleCrystalGroundTruthNeutron();
    else if(testName == "singlecrystal-simulate-show-graph") TestSingleCrystalSimulateThenShowGraph();
+   else if(testName == "singlecrystal-simulate-grouped-equal") TestSingleCrystalSimulateGroupedEquallySpaced();
+   else if(testName == "singlecrystal-simulate-grouped-user") TestSingleCrystalSimulateGroupedUserData();
    else
    {
       std::cerr << "Unknown test case: " << testName << std::endl;

--- a/test/unit/api_scattering.cpp
+++ b/test/unit/api_scattering.cpp
@@ -101,6 +101,45 @@ void TestSingleCrystalGroundTruthNeutron()
                                                "../../test/data/ground_truth/singlecrystal_neutron_pbso4.txt", 1e-2f, 1e-5f);
 }
 
+// Regression test for the crash in WXDiffractionSingleCrystal::OnMenuShowGraph
+// when called after OnMenuSimulate.
+//
+// OnMenuSimulate calls GenHKLFullSpace(), which generates reflections and
+// populates Icalc, but leaves Iobs empty.  OnMenuShowGraph then calls
+// CrystUpdate(), which iterates over Icalc.numElements() entries and reads
+// Iobs(i) at each step — a fatal out-of-bounds access when Iobs is empty.
+//
+// The fix is for GenHKLFullSpace (or a post-simulate step) to initialise Iobs
+// to a consistent size.  This test captures that contract: after
+// GenHKLFullSpace, GetIcalc() and GetIobs() must have the same number of
+// elements so that graph-display code can safely read both arrays in lockstep.
+void TestSingleCrystalSimulateThenShowGraph()
+{
+   using namespace ObjCryst;
+   Crystal c = MakePbso4Crystal();
+   DiffractionDataSingleCrystal sc(c, false);
+   sc.SetRadiationType(RAD_XRAY);
+   sc.SetWavelength(1.54056);
+
+   // Reproduce the OnMenuSimulate action: generate reflections up to 50 degrees
+   // theta (all reflections, no Friedel merging), then check that there are
+   // reflections (otherwise the test is vacuous).
+   sc.GenHKLFullSpace(50.0 * DEG2RAD, false);
+   Check(sc.GetNbRefl() > 0, "GenHKLFullSpace produced no reflections");
+
+   // GetIcalc() triggers CalcIcalc() and returns a non-empty array.
+   const long nbCalc = sc.GetIcalc().numElements();
+   Check(nbCalc > 0, "GetIcalc() is empty after GenHKLFullSpace");
+
+   // GetIobs() must return an array of the same size so that code iterating
+   // over both in lockstep (as CrystUpdate does when building the graph) does
+   // not read out of bounds.
+   const long nbObs = sc.GetIobs().numElements();
+   Check(nbObs == nbCalc,
+         "GetIobs() size differs from GetIcalc() size after GenHKLFullSpace: "
+         "crash would occur in WXDiffractionSingleCrystal::CrystUpdate");
+}
+
 } // namespace
 
 int main(int argc, char* argv[])
@@ -118,6 +157,7 @@ int main(int argc, char* argv[])
    else if(testName == "diffractiondata-observed") TestDiffractionDataSingleCrystalObservedData();
    else if(testName == "singlecrystal-groundtruth-xray") TestSingleCrystalGroundTruthXray();
    else if(testName == "singlecrystal-groundtruth-neutron") TestSingleCrystalGroundTruthNeutron();
+   else if(testName == "singlecrystal-simulate-show-graph") TestSingleCrystalSimulateThenShowGraph();
    else
    {
       std::cerr << "Unknown test case: " << testName << std::endl;

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -37,6 +37,8 @@ run_test "unit::diffractiondata-observed" "$SCRIPT_DIR/api_scattering" "diffract
 run_test "unit::singlecrystal-groundtruth-xray" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-xray"
 run_test "unit::singlecrystal-groundtruth-neutron" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-neutron"
 run_test "unit::singlecrystal-simulate-show-graph" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-show-graph"
+run_test "unit::singlecrystal-simulate-grouped-equal" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-grouped-equal"
+run_test "unit::singlecrystal-simulate-grouped-user" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-grouped-user"
 
 # --- api_cif ---
 run_test "unit::cif-import" "$SCRIPT_DIR/api_cif" "cif-import"

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -36,6 +36,7 @@ run_test "unit::scatteringdata-radiation-types" "$SCRIPT_DIR/api_scattering" "sc
 run_test "unit::diffractiondata-observed" "$SCRIPT_DIR/api_scattering" "diffractiondata-observed"
 run_test "unit::singlecrystal-groundtruth-xray" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-xray"
 run_test "unit::singlecrystal-groundtruth-neutron" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-neutron"
+run_test "unit::singlecrystal-simulate-show-graph" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-show-graph"
 
 # --- api_cif ---
 run_test "unit::cif-import" "$SCRIPT_DIR/api_cif" "cif-import"

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -36,7 +36,7 @@ run_test "unit::scatteringdata-radiation-types" "$SCRIPT_DIR/api_scattering" "sc
 run_test "unit::diffractiondata-observed" "$SCRIPT_DIR/api_scattering" "diffractiondata-observed"
 run_test "unit::singlecrystal-groundtruth-xray" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-xray"
 run_test "unit::singlecrystal-groundtruth-neutron" "$SCRIPT_DIR/api_scattering" "singlecrystal-groundtruth-neutron"
-run_test "unit::singlecrystal-simulate-show-graph" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-show-graph"
+run_test "unit::singlecrystal-simulate-ungrouped" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-ungrouped"
 run_test "unit::singlecrystal-simulate-grouped-equal" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-grouped-equal"
 run_test "unit::singlecrystal-simulate-grouped-user" "$SCRIPT_DIR/api_scattering" "singlecrystal-simulate-grouped-user"
 


### PR DESCRIPTION
## Summary
- initialize simulated single-crystal observed intensities after generating reflections
- support grouped single-crystal simulation for both equally-spaced and user-data grouping modes
- add regression coverage for ungrouped and grouped simulate workflows, and update the changelog

## Testing
- manual temp-binary build of `api_scattering`
- scatteringdata-singlecrystal
- scatteringdata-radiation-types
- diffractiondata-observed
- singlecrystal-groundtruth-xray
- singlecrystal-groundtruth-neutron
- singlecrystal-simulate-ungrouped
- singlecrystal-simulate-grouped-equal
- singlecrystal-simulate-grouped-user
