### PR TITLE
Fix anisotropic Pseudo-Voigt profile constructor

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -47,6 +47,7 @@ BUG FIXES
   * Relax powder ground-truth relative tolerance to 5e-4 so regression tests
     are stable in both single-precision (default) and double-precision builds
   * Add a Linux non-GUI CI matrix entry running tests in double precision
+  * Fix constructor of anisotropic Pseudo-Voigt profile (PR #93)
 
 #### 2024.1 (August 2024)
 NEW FEATURES

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -581,6 +581,7 @@ void ReflectionProfilePseudoVoigtAnisotropic::SetProfilePar(const REAL fwhmCagli
    mCagliotiU=fwhmCagliotiU;
    mCagliotiV=fwhmCagliotiV;
    mCagliotiW=fwhmCagliotiW;
+   mScherrerP=fwhmGaussP;
    mLorentzX=fwhmLorentzX;
    mLorentzY=fwhmLorentzY;
    mLorentzGammaHH=fwhmLorentzGammaHH;

--- a/ObjCryst/ObjCryst/ReflectionProfile.h
+++ b/ObjCryst/ObjCryst/ReflectionProfile.h
@@ -192,7 +192,7 @@ class ReflectionProfilePseudoVoigtAnisotropic:public ReflectionProfile
                          const REAL fwhmLorentzGammaKL=0,
                          const REAL pseudoVoigtEta0=0,
                          const REAL pseudoVoigtEta1=0,
-                         const REAL asymA0=0,
+                         const REAL asymA0=1,
                          const REAL asymA1=0,
                          const REAL asymA2=0
                          );

--- a/test/unit/api_powderpattern.cpp
+++ b/test/unit/api_powderpattern.cpp
@@ -233,6 +233,15 @@ void TestReflectionProfileDoubleExponentialPseudoVoigt()
 void TestReflectionProfilePseudoVoigtAnisotropicDirect()
 {
    using namespace ObjCryst;
+   ReflectionProfilePseudoVoigtAnisotropic parameterProfile;
+   const REAL w = 1e-6f;
+   const REAL p = 2e-6f;
+   parameterProfile.SetProfilePar(w, 0, 0, p);
+   CheckNearAbs(parameterProfile.GetPar("P").GetValue(), p, 1e-12,
+                "Anisotropic SetProfilePar should assign Gaussian P");
+   CheckNearAbs(parameterProfile.GetPar("Asym0").GetValue(), 1, 1e-12,
+                "Anisotropic SetProfilePar should default to symmetric Asym0");
+
    const REAL wavelength = 1.54056f;
    const REAL xMin = 10 * DEG2RAD;
    const REAL step = 0.05f * DEG2RAD;


### PR DESCRIPTION
It ignored `fwhmGaussP` from the input arguments. Now it sets `mScherrerP` from it. 

Also use `asymA0=1` by default. It corresponds to symmetric peak. It's what isotropic PV already does. 