### PR TITLE
Add PowderPatternBackgroundHist as scaled background histogram

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -20,6 +20,7 @@ NEW FEATURES
     stopping when the absolute change in Rwp [%] falls below it; like
     `minChi2var`, it is only checked when `nbCycle` is negative, and defaults
     to -1 (disabled) to preserve existing behavior (PR #91, @clemisch)
+  * Add PowderPatternBackgroundHist as scaled dense background
 
 IMPROVEMENTS
   * Indexing (CellExplorer): lower the default minimum unit cell length from

--- a/ObjCryst/ObjCryst/IO.cpp
+++ b/ObjCryst/ObjCryst/IO.cpp
@@ -1788,6 +1788,79 @@ void PowderPatternBackground::XMLInput(istream &is,const XMLCrystTag &tagg)
 }
 ////////////////////////////////////////////////////////////////////////
 //
+//    I/O PowderPatternBackgroundHist
+//
+////////////////////////////////////////////////////////////////////////
+void PowderPatternBackgroundHist::XMLOutput(ostream &os,int indent)const
+{
+   for(int i=0;i<indent;i++) os << "  ";
+   XMLCrystTag tag("PowderPatternBackgroundHist");
+   tag.AddAttribute("Name",this->GetName());
+   os <<tag<<endl;
+   indent++;
+
+   this->GetPar("Scale").XMLOutput(os,"Scale",indent);
+   os <<endl;
+
+   XMLCrystTag tag2("HistogramList");
+   for(int i=0;i<indent;i++) os << "  ";
+   os <<tag2<<endl;
+   for(long j=0;j<mHistogram.numElements();j++)
+   {
+      for(int i=0;i<=indent;i++) os << "  ";
+      os << mHistogram(j) <<endl;
+   }
+   tag2.SetIsEndTag(true);
+   for(int i=0;i<indent;i++) os << "  ";
+   os <<tag2<<endl;
+
+   indent--;
+   tag.SetIsEndTag(true);
+   for(int i=0;i<indent;i++) os << "  ";
+   os <<tag<<endl;
+}
+
+void PowderPatternBackgroundHist::XMLInput(istream &is,const XMLCrystTag &tagg)
+{
+   for(unsigned int i=0;i<tagg.GetNbAttribute();i++)
+      if("Name"==tagg.GetAttributeName(i)) this->SetName(tagg.GetAttributeValue(i));
+
+   while(true)
+   {
+      XMLCrystTag tag(is);
+      if(("PowderPatternBackgroundHist"==tag.GetName())&&tag.IsEndTag())
+      {
+         this->UpdateDisplay();
+         return;
+      }
+      if("HistogramList"==tag.GetName())
+      {
+         long nb=0;
+         CrystVector_REAL hist(1000);
+         do
+         {
+            is >> hist(nb);
+            nb++;
+            if(nb==hist.numElements()) hist.resizeAndPreserve(nb+1000);
+            while(0==isgraph(is.peek())) is.get();
+         }
+         while(is.peek()!='<');
+         hist.resizeAndPreserve(nb);
+         this->SetHistogram(hist);
+         XMLCrystTag junkEndTag(is);
+      }
+      if("Par"==tag.GetName())
+      {
+         for(unsigned int i=0;i<tag.GetNbAttribute();i++)
+            if("Name"==tag.GetAttributeName(i))
+               if("Scale"==tag.GetAttributeValue(i))
+                  this->GetPar("Scale").XMLInput(is,tag);
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
 //    I/O PowderPatternDiffraction
 //
 ////////////////////////////////////////////////////////////////////////
@@ -2349,6 +2422,13 @@ void PowderPattern::XMLInput(istream &is,const XMLCrystTag &tagg)
       if("PowderPatternBackground"==tag.GetName())
       {
          PowderPatternBackground *comp=new PowderPatternBackground;
+         comp->SetParentPowderPattern(*this);
+         comp->XMLInput(is,tag);
+         continue;
+      }
+      if("PowderPatternBackgroundHist"==tag.GetName())
+      {
+         PowderPatternBackgroundHist *comp=new PowderPatternBackgroundHist;
          comp->SetParentPowderPattern(*this);
          comp->XMLInput(is,tag);
          continue;

--- a/ObjCryst/ObjCryst/PowderPattern.cpp
+++ b/ObjCryst/ObjCryst/PowderPattern.cpp
@@ -795,6 +795,7 @@ mScale(1.0),
 mMaxSinThetaOvLambda(10)
 {
    mClockMaster.AddChild(mClockHistogram);
+   this->InitRefParList();
 }
 
 PowderPatternBackgroundHist::PowderPatternBackgroundHist(const PowderPatternBackgroundHist &old):
@@ -841,7 +842,6 @@ pair<const CrystVector_REAL*,const RefinableObjClock*>
 void PowderPatternBackgroundHist::SetHistogram(const CrystVector_REAL &histogram)
 {
    mHistogram=histogram;
-   this->InitRefParList();
    mClockHistogram.Click();
 }
 

--- a/ObjCryst/ObjCryst/PowderPattern.cpp
+++ b/ObjCryst/ObjCryst/PowderPattern.cpp
@@ -787,6 +787,237 @@ WXCrystObjBasic* PowderPatternBackground::WXCreate(wxWindow* parent)
 #endif
 ////////////////////////////////////////////////////////////////////////
 //
+//        PowderPatternBackgroundHist
+//
+////////////////////////////////////////////////////////////////////////
+PowderPatternBackgroundHist::PowderPatternBackgroundHist():
+mScale(1.0),
+mMaxSinThetaOvLambda(10)
+{
+   mClockMaster.AddChild(mClockHistogram);
+}
+
+PowderPatternBackgroundHist::PowderPatternBackgroundHist(const PowderPatternBackgroundHist &old):
+mHistogram(old.mHistogram),
+mScale(old.mScale),
+mMaxSinThetaOvLambda(old.mMaxSinThetaOvLambda)
+{
+   mClockMaster.AddChild(mClockHistogram);
+   this->InitRefParList();
+}
+
+PowderPatternBackgroundHist::~PowderPatternBackgroundHist(){}
+
+const string& PowderPatternBackgroundHist::GetClassName() const
+{
+   const static string className="PowderPatternBackgroundHist";
+   return className;
+}
+
+void PowderPatternBackgroundHist::SetParentPowderPattern(PowderPattern &s)
+{
+   if(mpParentPowderPattern!=0)
+      mClockMaster.RemoveChild(mpParentPowderPattern->GetIntegratedProfileLimitsClock());
+   mpParentPowderPattern = &s;
+   mClockMaster.AddChild(mpParentPowderPattern->GetIntegratedProfileLimitsClock());
+   mClockMaster.AddChild(mpParentPowderPattern->GetClockPowderPatternPar());
+   mClockMaster.AddChild(mpParentPowderPattern->GetClockPowderPatternXCorr());
+   mClockMaster.AddChild(mpParentPowderPattern->GetClockPowderPatternRadiation());
+}
+
+const CrystVector_REAL& PowderPatternBackgroundHist::GetPowderPatternCalc()const
+{
+   this->CalcPowderPattern();
+   return mPowderPatternCalc;
+}
+
+pair<const CrystVector_REAL*,const RefinableObjClock*>
+   PowderPatternBackgroundHist::GetPowderPatternIntegratedCalc()const
+{
+   this->CalcPowderPatternIntegrated();
+   return make_pair(&mPowderPatternIntegratedCalc,&mClockPowderPatternIntegratedCalc);
+}
+
+void PowderPatternBackgroundHist::SetHistogram(const CrystVector_REAL &histogram)
+{
+   mHistogram=histogram;
+   this->InitRefParList();
+   mClockHistogram.Click();
+}
+
+const CrystVector_REAL& PowderPatternBackgroundHist::GetHistogram()const
+{
+   return mHistogram;
+}
+
+void PowderPatternBackgroundHist::GetGeneGroup(const RefinableObj &obj,
+                            CrystVector_uint & groupIndex,
+                            unsigned int &first) const
+{
+   unsigned int index=0;
+   for(long i=0;i<obj.GetNbPar();i++)
+      for(long j=0;j<this->GetNbPar();j++)
+         if(&(obj.GetPar(i)) == &(this->GetPar(j)))
+         {
+            if(index==0) index=first++;
+            groupIndex(i)=index;
+         }
+}
+
+void PowderPatternBackgroundHist::BeginOptimization(const bool allowApproximations,
+                                                    const bool enableRestraints)
+{
+   this->RefinableObj::BeginOptimization(allowApproximations,enableRestraints);
+}
+
+const CrystVector_REAL& PowderPatternBackgroundHist::GetPowderPatternCalcVariance()const
+{
+   this->CalcPowderPattern();
+   return mPowderPatternCalcVariance;
+}
+
+pair<const CrystVector_REAL*,const RefinableObjClock*>
+   PowderPatternBackgroundHist::GetPowderPatternIntegratedCalcVariance()const
+{
+   this->CalcPowderPatternIntegrated();
+   return make_pair(&mPowderPatternIntegratedCalcVariance,
+                    &mClockPowderPatternIntegratedVarianceCalc);
+}
+
+bool PowderPatternBackgroundHist::HasPowderPatternCalcVariance()const {return false;}
+
+void PowderPatternBackgroundHist::TagNewBestConfig()const {}
+
+void PowderPatternBackgroundHist::CalcPowderPattern() const
+{
+   if(mClockPowderPatternCalc>mClockMaster) return;
+
+   const unsigned long nb=mpParentPowderPattern->GetNbPoint();
+   mPowderPatternCalc.resize(nb);
+   if(nb==0 || mHistogram.numElements()==0)
+   {
+      mPowderPatternCalc=0;
+   }
+   else
+   {
+      if((unsigned long)mHistogram.numElements()!=nb)
+         throw ObjCrystException("PowderPatternBackgroundHist::CalcPowderPattern():"
+                                 " histogram size does not match pattern size");
+      const REAL *h=mHistogram.data();
+      REAL *b=mPowderPatternCalc.data();
+      const REAL s=mScale;
+      for(unsigned long i=0;i<nb;i++) *b++ = s * *h++;
+   }
+   mClockPowderPatternCalc.Click();
+}
+
+void PowderPatternBackgroundHist::CalcPowderPattern_FullDeriv(std::set<RefinablePar*> &vPar)
+{
+   mPowderPattern_FullDeriv.clear();
+   const unsigned long nb=mpParentPowderPattern->GetNbPoint();
+   if(nb==0 || mHistogram.numElements()==0) return;
+
+   for(std::set<RefinablePar*>::iterator par=vPar.begin();par!=vPar.end();++par)
+   {
+      if(*par==0)
+      {
+         mPowderPattern_FullDeriv[*par]=this->GetPowderPatternCalc();
+      }
+      else if((*par)->GetPointer()==&mScale)
+      {
+         mPowderPattern_FullDeriv[*par]=mHistogram;
+         if(MaxAbs(mPowderPattern_FullDeriv[*par])==0)
+            mPowderPattern_FullDeriv[*par].resize(0);
+      }
+   }
+}
+
+void PowderPatternBackgroundHist::CalcPowderPatternIntegrated() const
+{
+   if(mClockPowderPatternCalc>mClockMaster) return;
+
+   this->CalcPowderPattern();
+   if(  (mClockPowderPatternIntegratedCalc>mClockPowderPatternCalc)
+      &&(mClockPowderPatternIntegratedCalc>mpParentPowderPattern->GetIntegratedProfileLimitsClock()))
+      return;
+
+   const CrystVector_long *pMin=&(mpParentPowderPattern->GetIntegratedProfileMin());
+   const CrystVector_long *pMax=&(mpParentPowderPattern->GetIntegratedProfileMax());
+   const long numInterval=pMin->numElements();
+   mPowderPatternIntegratedCalc.resize(numInterval);
+   REAL * RESTRICT p2=mPowderPatternIntegratedCalc.data();
+   for(int j=0;j<numInterval;j++)
+   {
+      const long max=(*pMax)(j);
+      const REAL * RESTRICT p1=mPowderPatternCalc.data()+(*pMin)(j);
+      *p2=0;
+      for(int k=(*pMin)(j);k<=max;k++) *p2 += *p1++;
+      p2++;
+   }
+   mClockPowderPatternIntegratedCalc.Click();
+}
+
+void PowderPatternBackgroundHist::CalcPowderPatternIntegrated_FullDeriv(std::set<RefinablePar*> &vPar)
+{
+   mPowderPatternIntegrated_FullDeriv.clear();
+   const unsigned long nb=mpParentPowderPattern->GetNbPoint();
+   if(nb==0 || mHistogram.numElements()==0) return;
+
+   const CrystVector_long *pMin=&(mpParentPowderPattern->GetIntegratedProfileMin());
+   const CrystVector_long *pMax=&(mpParentPowderPattern->GetIntegratedProfileMax());
+   const long numInterval=pMin->numElements();
+
+   for(std::set<RefinablePar*>::iterator par=vPar.begin();par!=vPar.end();++par)
+   {
+      if(*par==0)
+      {
+         mPowderPatternIntegrated_FullDeriv[*par]=*(this->GetPowderPatternIntegratedCalc().first);
+      }
+      else if((*par)->GetPointer()==&mScale)
+      {
+         CrystVector_REAL deriv(numInterval);
+         REAL * RESTRICT p2=deriv.data();
+         for(int j=0;j<numInterval;j++)
+         {
+            const long max=(*pMax)(j);
+            const REAL * RESTRICT p1=mHistogram.data()+(*pMin)(j);
+            *p2=0;
+            for(int k=(*pMin)(j);k<=max;k++) *p2 += *p1++;
+            p2++;
+         }
+         if(MaxAbs(deriv)==0) deriv.resize(0);
+         mPowderPatternIntegrated_FullDeriv[*par]=deriv;
+      }
+   }
+}
+
+void PowderPatternBackgroundHist::Prepare() {}
+
+const CrystVector_long& PowderPatternBackgroundHist::GetBraggLimits()const
+{
+   mIntegratedReflLimits.resize(0);
+   return mIntegratedReflLimits;
+}
+
+void PowderPatternBackgroundHist::SetMaxSinThetaOvLambda(const REAL max)
+{
+   mMaxSinThetaOvLambda=max;
+   mClockMaster.Click();
+}
+
+void PowderPatternBackgroundHist::InitRefParList()
+{
+   this->ResetParList();
+   RefinablePar tmp("Scale",&mScale,
+                    0.,1e10,gpRefParTypeScattDataBackground,REFPAR_DERIV_STEP_RELATIVE,
+                    true,true,true,false,1.);
+   tmp.AssignClock(mClockHistogram);
+   tmp.SetDerivStep(1e-4);
+   this->AddPar(tmp);
+}
+
+////////////////////////////////////////////////////////////////////////
+//
 //        PowderPatternDiffraction
 //
 ////////////////////////////////////////////////////////////////////////

--- a/ObjCryst/ObjCryst/PowderPattern.h
+++ b/ObjCryst/ObjCryst/PowderPattern.h
@@ -322,6 +322,64 @@ class PowderPatternBackground : public PowderPatternComponent
 };
 
 //######################################################################
+/** \brief Phase to compute a background contribution using a fixed histogram
+* scaled by a single refinable Scale parameter.
+*
+* The histogram must have the same number of points as the parent PowderPattern.
+* Only the overall Scale factor participates in LSQ refinement; the histogram
+* itself is fixed.
+*/
+//######################################################################
+class PowderPatternBackgroundHist : public PowderPatternComponent
+{
+   public:
+      PowderPatternBackgroundHist();
+      PowderPatternBackgroundHist(const PowderPatternBackgroundHist&);
+      virtual ~PowderPatternBackgroundHist();
+      virtual const string& GetClassName() const;
+
+      virtual void SetParentPowderPattern(PowderPattern&);
+      virtual const CrystVector_REAL& GetPowderPatternCalc()const;
+      virtual pair<const CrystVector_REAL*,const RefinableObjClock*>
+         GetPowderPatternIntegratedCalc()const;
+      /// Set the fixed background histogram (must match parent pattern length).
+      void SetHistogram(const CrystVector_REAL &histogram);
+      const CrystVector_REAL& GetHistogram()const;
+      virtual void XMLOutput(ostream &os,int indent=0)const;
+      virtual void XMLInput(istream &is,const XMLCrystTag &tag);
+      virtual void GetGeneGroup(const RefinableObj &obj,
+                                CrystVector_uint & groupIndex,
+                                unsigned int &firstGroup) const;
+      virtual void BeginOptimization(const bool allowApproximations=false,
+                                     const bool enableRestraints=false);
+      virtual const CrystVector_REAL& GetPowderPatternCalcVariance()const;
+      virtual pair<const CrystVector_REAL*,const RefinableObjClock*>
+         GetPowderPatternIntegratedCalcVariance() const;
+      virtual bool HasPowderPatternCalcVariance()const;
+      virtual void TagNewBestConfig()const;
+   protected:
+      virtual void CalcPowderPattern() const;
+      virtual void CalcPowderPattern_FullDeriv(std::set<RefinablePar *> &vPar);
+      virtual void CalcPowderPatternIntegrated() const;
+      virtual void CalcPowderPatternIntegrated_FullDeriv(std::set<RefinablePar *> &vPar);
+      virtual void Prepare();
+      virtual const CrystVector_long& GetBraggLimits()const;
+      virtual void SetMaxSinThetaOvLambda(const REAL max);
+      void InitRefParList();
+
+      /// Fixed background histogram
+      CrystVector_REAL mHistogram;
+      /// Scale factor applied to the histogram (the single refinable parameter)
+      REAL mScale;
+      /// Clock invalidated when histogram data or scale changes
+      RefinableObjClock mClockHistogram;
+
+      REAL mMaxSinThetaOvLambda;
+
+      friend class PowderPattern;
+};
+
+//######################################################################
 /** \brief Class to compute the contribution to a powder pattern from
 * a crystalline phase.
 *

--- a/test/unit/api_powderpattern.cpp
+++ b/test/unit/api_powderpattern.cpp
@@ -49,6 +49,68 @@ void TestPowderPatternBackground()
    Check(p.GetPowderPatternCalc().numElements() == p.GetNbPoint(), "PowderPattern calc size mismatch");
 }
 
+void TestPowderPatternBackgroundHist()
+{
+   using namespace ObjCryst;
+   PowderPattern p;
+   p.SetPowderPatternPar(0, 0.01 * DEG2RAD, 5);
+   CrystVector_REAL obs(5);
+   obs = 0;
+   p.SetPowderPatternObs(obs);
+
+   auto* bg = new PowderPatternBackgroundHist;
+   CrystVector_REAL hist(5);
+   for(long i=0;i<hist.numElements();++i) hist(i)=i+1;
+   bg->SetHistogram(hist);
+   p.AddPowderPatternComponent(*bg);
+
+   Check(p.GetNbPowderPatternComponent() == 1,
+         "Histogram background component not added");
+   Check(!bg->IsScalable(),
+         "Histogram background should use its own Scale parameter");
+   Check(bg->GetNbPar() == 1 && bg->GetPar(0L).GetName() == "Scale",
+         "Histogram background should have one Scale parameter");
+
+   const CrystVector_REAL stored = bg->GetHistogram();
+   for(long i=0;i<hist.numElements();++i)
+      CheckNearAbs(stored(i),hist(i),1e-12,
+                   "Histogram background data mismatch");
+
+   bg->GetPar("Scale").SetValue(2.5);
+   const CrystVector_REAL componentCalc = bg->GetPowderPatternCalc();
+   const CrystVector_REAL patternCalc = p.GetPowderPatternCalc();
+   for(long i=0;i<hist.numElements();++i)
+   {
+      const REAL expected=2.5*hist(i);
+      CheckNearAbs(componentCalc(i),expected,1e-12,
+                   "Histogram component scaling mismatch");
+      CheckNearAbs(patternCalc(i),expected,1e-12,
+                   "Histogram contribution to powder pattern mismatch");
+   }
+
+   hist=3;
+   bg->SetHistogram(hist);
+   const CrystVector_REAL updatedCalc = bg->GetPowderPatternCalc();
+   for(long i=0;i<hist.numElements();++i)
+      CheckNearAbs(updatedCalc(i),7.5,1e-12,
+                   "Updated histogram did not invalidate calculation");
+
+   CrystVector_REAL wrongSize(4);
+   wrongSize=1;
+   bg->SetHistogram(wrongSize);
+   bool mismatchThrown=false;
+   try
+   {
+      bg->GetPowderPatternCalc();
+   }
+   catch(const ObjCrystException&)
+   {
+      mismatchThrown=true;
+   }
+   Check(mismatchThrown,
+         "Histogram size mismatch should raise ObjCrystException");
+}
+
 void TestPowderPatternDiffraction()
 {
    using namespace ObjCryst;
@@ -351,6 +413,7 @@ int main(int argc, char* argv[])
    const std::string testName = argv[1];
 
    if(testName == "powderpattern-background") TestPowderPatternBackground();
+   else if(testName == "powderpattern-background-hist") TestPowderPatternBackgroundHist();
    else if(testName == "powderpattern-diffraction") TestPowderPatternDiffraction();
    else if(testName == "powderpattern-diffraction-mur") TestPowderPatternDiffractionMuRAbsorption();
    else if(testName == "powderpattern-diffraction-lebail-fhklobs") TestPowderPatternDiffractionLeBailFhklObsSq();

--- a/test/unit/api_powderpattern.cpp
+++ b/test/unit/api_powderpattern.cpp
@@ -3,6 +3,7 @@
 // ScatteringCorr subclasses.
 #include <cmath>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "ObjCryst/ObjCryst/Crystal.h"
@@ -109,6 +110,39 @@ void TestPowderPatternBackgroundHist()
    }
    Check(mismatchThrown,
          "Histogram size mismatch should raise ObjCrystException");
+}
+
+void TestPowderPatternBackgroundHistXML()
+{
+   using namespace ObjCryst;
+   PowderPatternBackgroundHist source;
+   source.SetName("dense background");
+   CrystVector_REAL hist(4);
+   for(long i=0;i<hist.numElements();++i) hist(i)=0.25*(i+1);
+   source.SetHistogram(hist);
+   source.GetPar("Scale").SetValue(3.5);
+   source.GetPar("Scale").SetIsFixed(false);
+
+   std::stringstream xml;
+   source.XMLOutput(xml,0);
+   XMLCrystTag tag(xml);
+   PowderPatternBackgroundHist restored;
+   restored.XMLInput(xml,tag);
+
+   Check(restored.GetName() == source.GetName(),
+         "Histogram background XML did not restore the name");
+   Check(restored.GetNbPar() == 1,
+         "Histogram background XML did not restore the Scale parameter");
+   CheckNearAbs(restored.GetPar("Scale").GetValue(),3.5,1e-12,
+                "Histogram background XML did not restore Scale");
+   Check(!restored.GetPar("Scale").IsFixed(),
+         "Histogram background XML did not restore Scale refinement state");
+   const CrystVector_REAL restoredHist = restored.GetHistogram();
+   Check(restoredHist.numElements() == hist.numElements(),
+         "Histogram background XML restored the wrong histogram size");
+   for(long i=0;i<hist.numElements();++i)
+      CheckNearAbs(restoredHist(i),hist(i),1e-12,
+                   "Histogram background XML data mismatch");
 }
 
 void TestPowderPatternDiffraction()
@@ -414,6 +448,7 @@ int main(int argc, char* argv[])
 
    if(testName == "powderpattern-background") TestPowderPatternBackground();
    else if(testName == "powderpattern-background-hist") TestPowderPatternBackgroundHist();
+   else if(testName == "powderpattern-background-hist-xml") TestPowderPatternBackgroundHistXML();
    else if(testName == "powderpattern-diffraction") TestPowderPatternDiffraction();
    else if(testName == "powderpattern-diffraction-mur") TestPowderPatternDiffractionMuRAbsorption();
    else if(testName == "powderpattern-diffraction-lebail-fhklobs") TestPowderPatternDiffractionLeBailFhklObsSq();

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -72,6 +72,7 @@ run_test "unit::cellexplorer-dicvol-monoclinic" "$SCRIPT_DIR/api_indexing" "cell
 
 # --- api_powderpattern ---
 run_test "unit::powderpattern-background" "$SCRIPT_DIR/api_powderpattern" "powderpattern-background"
+run_test "unit::powderpattern-background-hist" "$SCRIPT_DIR/api_powderpattern" "powderpattern-background-hist"
 run_test "unit::powderpattern-diffraction" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction"
 run_test "unit::powderpattern-diffraction-mur" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction-mur"
 run_test "unit::powderpattern-diffraction-lebail-fhklobs" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction-lebail-fhklobs"

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -73,6 +73,7 @@ run_test "unit::cellexplorer-dicvol-monoclinic" "$SCRIPT_DIR/api_indexing" "cell
 # --- api_powderpattern ---
 run_test "unit::powderpattern-background" "$SCRIPT_DIR/api_powderpattern" "powderpattern-background"
 run_test "unit::powderpattern-background-hist" "$SCRIPT_DIR/api_powderpattern" "powderpattern-background-hist"
+run_test "unit::powderpattern-background-hist-xml" "$SCRIPT_DIR/api_powderpattern" "powderpattern-background-hist-xml"
 run_test "unit::powderpattern-diffraction" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction"
 run_test "unit::powderpattern-diffraction-mur" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction-mur"
 run_test "unit::powderpattern-diffraction-lebail-fhklobs" "$SCRIPT_DIR/api_powderpattern" "powderpattern-diffraction-lebail-fhklobs"


### PR DESCRIPTION
Add new PowderPatternComponent `PowderPatternBackgroundHist`. It's to be used as a dense scaled background, taken from some background measurement (substrate). 

It has only one parameter `Scale`. In contrast to PowderPatternDiffraction this scale lives on PowderPatternBackgroundHist itself, such that it is not changed by `PowderPattern.FitScaleFactorFor...`.