### PR TITLE
Add profile ReflectionProfilePseudoVoigtTCH with TCH instead of explicit Eta mixing

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -21,6 +21,8 @@ NEW FEATURES
     `minChi2var`, it is only checked when `nbCycle` is negative, and defaults
     to -1 (disabled) to preserve existing behavior (PR #91, @clemisch)
   * Add PowderPatternBackgroundHist as scaled dense background
+  * Add profile ReflectionProfilePseudoVoigtTCH for full Pseudo-Voigt parameterization
+    with X,Y,Z,U,V,W and implicit Eta mixing
 
 IMPROVEMENTS
   * Indexing (CellExplorer): lower the default minimum unit cell length from

--- a/ObjCryst/ObjCryst/IO.cpp
+++ b/ObjCryst/ObjCryst/IO.cpp
@@ -2091,6 +2091,20 @@ void PowderPatternDiffraction::XMLInput(istream &is,const XMLCrystTag &tagg)
          mpReflectionProfile->XMLInput(is,tag);
          continue;
       }
+      if("ReflectionProfilePseudoVoigtTCH"==tag.GetName())
+      {
+         if(mpReflectionProfile==0)
+         {
+            mpReflectionProfile=new ReflectionProfilePseudoVoigtTCH;
+         }
+         else
+            if(mpReflectionProfile->GetClassName()!="ReflectionProfilePseudoVoigtTCH")
+            {
+               this->SetProfile(new ReflectionProfilePseudoVoigtTCH);
+            }
+         mpReflectionProfile->XMLInput(is,tag);
+         continue;
+      }
       if("ReflectionProfilePseudoVoigtAnisotropic"==tag.GetName())
       {
          if(mpReflectionProfile==0)

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -487,7 +487,7 @@ WXCrystObjBasic* ReflectionProfilePseudoVoigt::WXCreate(wxWindow* parent)
 
 ReflectionProfilePseudoVoigtTCH::ReflectionProfilePseudoVoigtTCH():
 mCagliotiU(0),mCagliotiV(0),mCagliotiW(.01*DEG2RAD*DEG2RAD),
-mLorentzX(0),mLorentzY(0),mLorentzZ(0)
+mLorentzX(0),mLorentzY(0),mLorentzZ(0),mScherrerP(0),mScherrerLGmix(1)
 {
    this->InitParameters();
 }
@@ -495,7 +495,8 @@ mLorentzX(0),mLorentzY(0),mLorentzZ(0)
 ReflectionProfilePseudoVoigtTCH::ReflectionProfilePseudoVoigtTCH
    (const ReflectionProfilePseudoVoigtTCH &old):
 mCagliotiU(old.mCagliotiU),mCagliotiV(old.mCagliotiV),mCagliotiW(old.mCagliotiW),
-mLorentzX(old.mLorentzX),mLorentzY(old.mLorentzY),mLorentzZ(old.mLorentzZ)
+mLorentzX(old.mLorentzX),mLorentzY(old.mLorentzY),mLorentzZ(old.mLorentzZ),
+mScherrerP(old.mScherrerP),mScherrerLGmix(old.mScherrerLGmix)
 {
    this->InitParameters();
 }
@@ -528,9 +529,17 @@ void ReflectionProfilePseudoVoigtTCH::GetProfilePar(const REAL center,
    const REAL tantheta=tan(center/2.0);
    const REAL costheta=cos(center/2.0);
    REAL fwhmG2=mCagliotiW+mCagliotiV*tantheta+mCagliotiU*tantheta*tantheta;
+   REAL lgmix=mScherrerLGmix;
+   if(lgmix<0) lgmix=0;
+   if(lgmix>1) lgmix=1;
+   REAL fwhmSize=mScherrerP/costheta;
+   if(fwhmSize<0) fwhmSize=0;
+   const REAL fwhmSizeG=(1-lgmix)*fwhmSize;
+   fwhmG2+=fwhmSizeG*fwhmSizeG;
    if(fwhmG2<0) fwhmG2=0;
    const REAL fwhmG=sqrt(fwhmG2);
-   REAL fwhmL=mLorentzZ+mLorentzX/costheta+mLorentzY*tantheta;
+   REAL fwhmL=mLorentzZ+mLorentzX/costheta+mLorentzY*tantheta
+              +lgmix*fwhmSize;
    if(fwhmL<0) fwhmL=0;
 
    const REAL fwhmG2p=fwhmG*fwhmG;
@@ -575,12 +584,24 @@ void ReflectionProfilePseudoVoigtTCH::SetProfilePar
     const REAL fwhmCagliotiV, const REAL fwhmLorentzX,
     const REAL fwhmLorentzY, const REAL fwhmLorentzZ)
 {
+   this->SetProfilePar(fwhmCagliotiW,fwhmCagliotiU,fwhmCagliotiV,
+                       fwhmLorentzX,fwhmLorentzY,fwhmLorentzZ,0,1);
+}
+
+void ReflectionProfilePseudoVoigtTCH::SetProfilePar
+   (const REAL fwhmCagliotiW, const REAL fwhmCagliotiU,
+    const REAL fwhmCagliotiV, const REAL fwhmLorentzX,
+    const REAL fwhmLorentzY, const REAL fwhmLorentzZ,
+    const REAL fwhmScherrerP, const REAL scherrerLGmix)
+{
    mCagliotiW=fwhmCagliotiW;
    mCagliotiU=fwhmCagliotiU;
    mCagliotiV=fwhmCagliotiV;
    mLorentzX=fwhmLorentzX;
    mLorentzY=fwhmLorentzY;
    mLorentzZ=fwhmLorentzZ;
+   mScherrerP=fwhmScherrerP;
+   mScherrerLGmix=scherrerLGmix;
    mClockMaster.Click();
 }
 
@@ -637,6 +658,8 @@ void ReflectionProfilePseudoVoigtTCH::XMLOutput(ostream &os,int indent)const
    this->GetPar(&mLorentzX).XMLOutput(os,"X",indent); os <<endl;
    this->GetPar(&mLorentzY).XMLOutput(os,"Y",indent); os <<endl;
    this->GetPar(&mLorentzZ).XMLOutput(os,"Z",indent); os <<endl;
+   this->GetPar(&mScherrerP).XMLOutput(os,"P",indent); os <<endl;
+   this->GetPar(&mScherrerLGmix).XMLOutput(os,"LGmix",indent); os <<endl;
    indent--;
    tag.SetIsEndTag(true);
    for(int i=0;i<indent;i++) os << "  ";
@@ -667,6 +690,8 @@ void ReflectionProfilePseudoVoigtTCH::XMLInput(istream &is,const XMLCrystTag &ta
             else if("X"==name) this->GetPar(&mLorentzX).XMLInput(is,tag);
             else if("Y"==name) this->GetPar(&mLorentzY).XMLInput(is,tag);
             else if("Z"==name) this->GetPar(&mLorentzZ).XMLInput(is,tag);
+            else if("P"==name) this->GetPar(&mScherrerP).XMLInput(is,tag);
+            else if("LGmix"==name) this->GetPar(&mScherrerLGmix).XMLInput(is,tag);
             break;
          }
          continue;
@@ -717,6 +742,18 @@ void ReflectionProfilePseudoVoigtTCH::InitParameters()
                        gpRefParTypeScattDataProfileWidth,
                        REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG);
       tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("P",&mScherrerP,0,1./RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("LGmix",&mScherrerLGmix,0,1,
+                       gpRefParTypeScattDataProfileType,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,1);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-4); this->AddPar(tmp);
    }
 }
 

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -570,9 +570,9 @@ CrystVector_REAL ReflectionProfilePseudoVoigtTCH::GetProfile
 {
    REAL fwhm,eta;
    this->GetProfilePar(center,fwhm,eta);
-   CrystVector_REAL profile=PowderProfileGauss(x,fwhm,center);
+   CrystVector_REAL profile=PowderProfileGauss(x,fwhm,center,(REAL)1.0);
    profile*=1-eta;
-   CrystVector_REAL lorentz=PowderProfileLorentz(x,fwhm,center);
+   CrystVector_REAL lorentz=PowderProfileLorentz(x,fwhm,center,(REAL)1.0);
    lorentz*=eta;
    profile+=lorentz;
 

--- a/ObjCryst/ObjCryst/ReflectionProfile.cpp
+++ b/ObjCryst/ObjCryst/ReflectionProfile.cpp
@@ -481,6 +481,255 @@ WXCrystObjBasic* ReflectionProfilePseudoVoigt::WXCreate(wxWindow* parent)
 
 ////////////////////////////////////////////////////////////////////////
 //
+//    ReflectionProfilePseudoVoigtTCH
+//
+////////////////////////////////////////////////////////////////////////
+
+ReflectionProfilePseudoVoigtTCH::ReflectionProfilePseudoVoigtTCH():
+mCagliotiU(0),mCagliotiV(0),mCagliotiW(.01*DEG2RAD*DEG2RAD),
+mLorentzX(0),mLorentzY(0),mLorentzZ(0)
+{
+   this->InitParameters();
+}
+
+ReflectionProfilePseudoVoigtTCH::ReflectionProfilePseudoVoigtTCH
+   (const ReflectionProfilePseudoVoigtTCH &old):
+mCagliotiU(old.mCagliotiU),mCagliotiV(old.mCagliotiV),mCagliotiW(old.mCagliotiW),
+mLorentzX(old.mLorentzX),mLorentzY(old.mLorentzY),mLorentzZ(old.mLorentzZ)
+{
+   this->InitParameters();
+}
+
+ReflectionProfilePseudoVoigtTCH::~ReflectionProfilePseudoVoigtTCH()
+{
+   #ifdef __WX__CRYST__
+   if(mpWXCrystObj!=0)
+   {
+      delete mpWXCrystObj;
+      mpWXCrystObj=0;
+   }
+   #endif
+}
+
+ReflectionProfilePseudoVoigtTCH* ReflectionProfilePseudoVoigtTCH::CreateCopy()const
+{
+   return new ReflectionProfilePseudoVoigtTCH(*this);
+}
+
+const string& ReflectionProfilePseudoVoigtTCH::GetClassName()const
+{
+   static string className="ReflectionProfilePseudoVoigtTCH";
+   return className;
+}
+
+void ReflectionProfilePseudoVoigtTCH::GetProfilePar(const REAL center,
+                                                     REAL &fwhm, REAL &eta)const
+{
+   const REAL tantheta=tan(center/2.0);
+   const REAL costheta=cos(center/2.0);
+   REAL fwhmG2=mCagliotiW+mCagliotiV*tantheta+mCagliotiU*tantheta*tantheta;
+   if(fwhmG2<0) fwhmG2=0;
+   const REAL fwhmG=sqrt(fwhmG2);
+   REAL fwhmL=mLorentzZ+mLorentzX/costheta+mLorentzY*tantheta;
+   if(fwhmL<0) fwhmL=0;
+
+   const REAL fwhmG2p=fwhmG*fwhmG;
+   const REAL fwhmL2=fwhmL*fwhmL;
+   const REAL fwhm5=fwhmG2p*fwhmG2p*fwhmG
+                    +2.69269*fwhmG2p*fwhmG2p*fwhmL
+                    +2.42843*fwhmG2p*fwhmG*fwhmL2
+                    +4.47163*fwhmG2p*fwhmL2*fwhmL
+                    +0.07842*fwhmG*fwhmL2*fwhmL2
+                    +fwhmL2*fwhmL2*fwhmL;
+   if(fwhm5<=0)
+   {
+      fwhm=1e-6;
+      eta=0;
+      return;
+   }
+
+   fwhm=pow(fwhm5,(REAL)0.2);
+   const REAL ratio=fwhmL/fwhm;
+   eta=1.36603*ratio-0.47719*ratio*ratio+0.11116*ratio*ratio*ratio;
+   if(eta<0) eta=0;
+   if(eta>1) eta=1;
+}
+
+CrystVector_REAL ReflectionProfilePseudoVoigtTCH::GetProfile
+   (const CrystVector_REAL &x, const REAL center,
+    const REAL h, const REAL k, const REAL l)const
+{
+   REAL fwhm,eta;
+   this->GetProfilePar(center,fwhm,eta);
+   CrystVector_REAL profile=PowderProfileGauss(x,fwhm,center);
+   profile*=1-eta;
+   CrystVector_REAL lorentz=PowderProfileLorentz(x,fwhm,center);
+   lorentz*=eta;
+   profile+=lorentz;
+
+   return profile;
+}
+
+void ReflectionProfilePseudoVoigtTCH::SetProfilePar
+   (const REAL fwhmCagliotiW, const REAL fwhmCagliotiU,
+    const REAL fwhmCagliotiV, const REAL fwhmLorentzX,
+    const REAL fwhmLorentzY, const REAL fwhmLorentzZ)
+{
+   mCagliotiW=fwhmCagliotiW;
+   mCagliotiU=fwhmCagliotiU;
+   mCagliotiV=fwhmCagliotiV;
+   mLorentzX=fwhmLorentzX;
+   mLorentzY=fwhmLorentzY;
+   mLorentzZ=fwhmLorentzZ;
+   mClockMaster.Click();
+}
+
+REAL ReflectionProfilePseudoVoigtTCH::GetFullProfileWidth
+   (const REAL relativeIntensity, const REAL center,
+    const REAL h, const REAL k, const REAL l)
+{
+   if((relativeIntensity<=0)||(relativeIntensity>=1))
+      throw ObjCrystException("ReflectionProfilePseudoVoigtTCH::GetFullProfileWidth(): relative intensity must be between 0 and 1");
+
+   REAL fwhm,eta;
+   this->GetProfilePar(center,fwhm,eta);
+   const REAL gaussPeak=2*sqrt(log((REAL)2.0)/M_PI)*(1-eta);
+   const REAL lorentzPeak=2*eta/M_PI;
+   const REAL target=relativeIntensity*(gaussPeak+lorentzPeak);
+   REAL lower=0;
+   REAL upper=.5;
+   while(true)
+   {
+      const REAL upper2=upper*upper;
+      const REAL value=gaussPeak*exp(-4*log((REAL)2.0)*upper2)
+                      +lorentzPeak/(1+4*upper2);
+      if(value<=target) break;
+      upper*=2;
+   }
+   for(unsigned int i=0;i<60;i++)
+   {
+      const REAL middle=(lower+upper)/2;
+      const REAL middle2=middle*middle;
+      const REAL value=gaussPeak*exp(-4*log((REAL)2.0)*middle2)
+                      +lorentzPeak/(1+4*middle2);
+      if(value>target) lower=middle;
+      else upper=middle;
+   }
+   const REAL width=(lower+upper)*fwhm;
+
+   return width;
+}
+
+bool ReflectionProfilePseudoVoigtTCH::IsAnisotropic()const
+{
+   return false;
+}
+
+void ReflectionProfilePseudoVoigtTCH::XMLOutput(ostream &os,int indent)const
+{
+   for(int i=0;i<indent;i++) os << "  ";
+   XMLCrystTag tag("ReflectionProfilePseudoVoigtTCH");
+   os <<tag<<endl;
+   indent++;
+   this->GetPar(&mCagliotiU).XMLOutput(os,"U",indent); os <<endl;
+   this->GetPar(&mCagliotiV).XMLOutput(os,"V",indent); os <<endl;
+   this->GetPar(&mCagliotiW).XMLOutput(os,"W",indent); os <<endl;
+   this->GetPar(&mLorentzX).XMLOutput(os,"X",indent); os <<endl;
+   this->GetPar(&mLorentzY).XMLOutput(os,"Y",indent); os <<endl;
+   this->GetPar(&mLorentzZ).XMLOutput(os,"Z",indent); os <<endl;
+   indent--;
+   tag.SetIsEndTag(true);
+   for(int i=0;i<indent;i++) os << "  ";
+   os <<tag<<endl;
+}
+
+void ReflectionProfilePseudoVoigtTCH::XMLInput(istream &is,const XMLCrystTag &tagg)
+{
+   for(unsigned int i=0;i<tagg.GetNbAttribute();i++)
+      if("Name"==tagg.GetAttributeName(i)) this->SetName(tagg.GetAttributeValue(i));
+   while(true)
+   {
+      XMLCrystTag tag(is);
+      if(("ReflectionProfilePseudoVoigtTCH"==tag.GetName())&&tag.IsEndTag())
+      {
+         this->UpdateDisplay();
+         return;
+      }
+      if("Par"==tag.GetName())
+      {
+         for(unsigned int i=0;i<tag.GetNbAttribute();i++)
+         {
+            if("Name"!=tag.GetAttributeName(i)) continue;
+            const string name=tag.GetAttributeValue(i);
+            if("U"==name) this->GetPar(&mCagliotiU).XMLInput(is,tag);
+            else if("V"==name) this->GetPar(&mCagliotiV).XMLInput(is,tag);
+            else if("W"==name) this->GetPar(&mCagliotiW).XMLInput(is,tag);
+            else if("X"==name) this->GetPar(&mLorentzX).XMLInput(is,tag);
+            else if("Y"==name) this->GetPar(&mLorentzY).XMLInput(is,tag);
+            else if("Z"==name) this->GetPar(&mLorentzZ).XMLInput(is,tag);
+            break;
+         }
+         continue;
+      }
+      if("Option"==tag.GetName())
+      {
+         for(unsigned int i=0;i<tag.GetNbAttribute();i++)
+            if("Name"==tag.GetAttributeName(i))
+               mOptionRegistry.GetObj(tag.GetAttributeValue(i)).XMLInput(is,tag);
+      }
+   }
+}
+
+void ReflectionProfilePseudoVoigtTCH::InitParameters()
+{
+   {
+      RefinablePar tmp("U",&mCagliotiU,-1/RAD2DEG/RAD2DEG,1./RAD2DEG/RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("V",&mCagliotiV,-1/RAD2DEG/RAD2DEG,1./RAD2DEG/RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("W",&mCagliotiW,0,1./RAD2DEG/RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG*RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("X",&mLorentzX,0,1./RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("Y",&mLorentzY,-1./RAD2DEG,1./RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+   {
+      RefinablePar tmp("Z",&mLorentzZ,0,1./RAD2DEG,
+                       gpRefParTypeScattDataProfileWidth,
+                       REFPAR_DERIV_STEP_ABSOLUTE,true,true,true,false,RAD2DEG);
+      tmp.AssignClock(mClockMaster); tmp.SetDerivStep(1e-9); this->AddPar(tmp);
+   }
+}
+
+#ifdef __WX__CRYST__
+WXCrystObjBasic* ReflectionProfilePseudoVoigtTCH::WXCreate(wxWindow* parent)
+{
+   if(mpWXCrystObj==0) mpWXCrystObj=new WXRefinableObj(parent,this);
+   return mpWXCrystObj;
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////
+//
 //    ReflectionProfilePseudoVoigtAnisotropic
 //
 ////////////////////////////////////////////////////////////////////////

--- a/ObjCryst/ObjCryst/ReflectionProfile.h
+++ b/ObjCryst/ObjCryst/ReflectionProfile.h
@@ -157,6 +157,52 @@ class ReflectionProfilePseudoVoigt:public ReflectionProfile
 #endif
 };
 
+/** Symmetric Thompson-Cox-Hastings pseudo-Voigt reflection profile.
+ *
+ * The Gaussian and Lorentzian component widths are described by
+ * \f[H_G^2=U\tan^2\theta+V\tan\theta+W\f]
+ * and
+ * \f[H_L=X/\cos\theta+Y\tan\theta+Z\f].
+ * The common pseudo-Voigt FWHM and mixing fraction are calculated using the
+ * Thompson-Cox-Hastings approximation; the mixing fraction is not an
+ * independent refinable parameter.
+ */
+class ReflectionProfilePseudoVoigtTCH:public ReflectionProfile
+{
+   public:
+      ReflectionProfilePseudoVoigtTCH();
+      ReflectionProfilePseudoVoigtTCH(const ReflectionProfilePseudoVoigtTCH &old);
+      virtual ~ReflectionProfilePseudoVoigtTCH();
+      virtual ReflectionProfilePseudoVoigtTCH* CreateCopy()const;
+      virtual const string& GetClassName()const;
+      CrystVector_REAL GetProfile(const CrystVector_REAL &x, const REAL xcenter,
+                                  const REAL h, const REAL k, const REAL l)const;
+      /** Set the Gaussian Caglioti parameters W, U, V and Lorentzian
+       * parameters X, Y, Z.
+       */
+      void SetProfilePar(const REAL fwhmCagliotiW,
+                         const REAL fwhmCagliotiU=0,
+                         const REAL fwhmCagliotiV=0,
+                         const REAL fwhmLorentzX=0,
+                         const REAL fwhmLorentzY=0,
+                         const REAL fwhmLorentzZ=0);
+      virtual REAL GetFullProfileWidth(const REAL relativeIntensity, const REAL xcenter,
+                                       const REAL h, const REAL k, const REAL l);
+      bool IsAnisotropic()const;
+      virtual void XMLOutput(ostream &os,int indent=0)const;
+      virtual void XMLInput(istream &is,const XMLCrystTag &tag);
+   private:
+      /// Calculate the common TCH FWHM and derived Lorentzian fraction.
+      void GetProfilePar(const REAL xcenter, REAL &fwhm, REAL &eta)const;
+      void InitParameters();
+      REAL mCagliotiU,mCagliotiV,mCagliotiW;
+      REAL mLorentzX,mLorentzY,mLorentzZ;
+#ifdef __WX__CRYST__
+   public:
+      virtual WXCrystObjBasic* WXCreate(wxWindow* parent);
+#endif
+};
+
 /** Pseudo-Voigt reflection profile, with 6-parameters anisotropic Lorentzian broadening and Toraya asymmetric modelling.
  *
  */

--- a/ObjCryst/ObjCryst/ReflectionProfile.h
+++ b/ObjCryst/ObjCryst/ReflectionProfile.h
@@ -160,12 +160,15 @@ class ReflectionProfilePseudoVoigt:public ReflectionProfile
 /** Symmetric Thompson-Cox-Hastings pseudo-Voigt reflection profile.
  *
  * The Gaussian and Lorentzian component widths are described by
- * \f[H_G^2=U\tan^2\theta+V\tan\theta+W\f]
+ * \f[H_G^2=U\tan^2\theta+V\tan\theta+W+
+ * ((1-LGmix)P/\cos\theta)^2\f]
  * and
- * \f[H_L=X/\cos\theta+Y\tan\theta+Z\f].
+ * \f[H_L=X/\cos\theta+Y\tan\theta+Z+LGmix P/\cos\theta\f].
  * The common pseudo-Voigt FWHM and mixing fraction are calculated using the
  * Thompson-Cox-Hastings approximation; the mixing fraction is not an
- * independent refinable parameter.
+ * independent refinable parameter. P is the Scherrer width coefficient
+ * K lambda/L in radians, and LGmix distributes that size broadening between
+ * the Gaussian and Lorentzian component widths.
  */
 class ReflectionProfilePseudoVoigtTCH:public ReflectionProfile
 {
@@ -186,6 +189,17 @@ class ReflectionProfilePseudoVoigtTCH:public ReflectionProfile
                          const REAL fwhmLorentzX=0,
                          const REAL fwhmLorentzY=0,
                          const REAL fwhmLorentzZ=0);
+      /** Set all profile parameters, including the Scherrer coefficient P
+       * and its Lorentzian fraction LGmix.
+       */
+      void SetProfilePar(const REAL fwhmCagliotiW,
+                         const REAL fwhmCagliotiU,
+                         const REAL fwhmCagliotiV,
+                         const REAL fwhmLorentzX,
+                         const REAL fwhmLorentzY,
+                         const REAL fwhmLorentzZ,
+                         const REAL fwhmScherrerP,
+                         const REAL scherrerLGmix);
       virtual REAL GetFullProfileWidth(const REAL relativeIntensity, const REAL xcenter,
                                        const REAL h, const REAL k, const REAL l);
       bool IsAnisotropic()const;
@@ -197,6 +211,7 @@ class ReflectionProfilePseudoVoigtTCH:public ReflectionProfile
       void InitParameters();
       REAL mCagliotiU,mCagliotiV,mCagliotiW;
       REAL mLorentzX,mLorentzY,mLorentzZ;
+      REAL mScherrerP,mScherrerLGmix;
 #ifdef __WX__CRYST__
    public:
       virtual WXCrystObjBasic* WXCreate(wxWindow* parent);

--- a/ObjCryst/RefinableObj/LSQNumObj.cpp
+++ b/ObjCryst/RefinableObj/LSQNumObj.cpp
@@ -922,12 +922,17 @@ const std::map<pair<const RefinablePar*,const RefinablePar*>,REAL > & LSQNumObj:
 
 void LSQNumObj::PrepareRefParList(const bool copy_param)
 {
+   this->PrepareRefParList(copy_param,true);
+}
+
+void LSQNumObj::PrepareRefParList(const bool copy_param,const bool verbose)
+{
    mRefParList.ResetParList();
    for(map<RefinableObj*,unsigned int>::iterator pos=mvRefinedObjMap.begin();pos!=mvRefinedObjMap.end();++pos)
    {
       VFN_DEBUG_MESSAGE("LSQNumObj::PrepareRefParList():"<<pos->first->GetName(),4);
       //mRecursiveRefinedObjList.GetObj(i).Print();
-      mRefParList.AddPar(*(pos->first),copy_param);
+      mRefParList.AddPar(*(pos->first),copy_param,verbose);
    }
    //mRefParList.Print();
    if(copy_param) mRefParList.SetDeleteRefParInDestructor(true);

--- a/ObjCryst/RefinableObj/LSQNumObj.h
+++ b/ObjCryst/RefinableObj/LSQNumObj.h
@@ -197,8 +197,12 @@ class LSQNumObj
       *
       * \note This will be called automatically before starting the refinement only if
       * the parameter list is empty. Otherwise it should be called before refinement.
+      *
+      * The two-argument overload allows warnings about duplicate hierarchy
+      * names to be disabled with verbose=false.
       */
       void PrepareRefParList(const bool copy_param=false);
+      void PrepareRefParList(const bool copy_param, const bool verbose);
 
       /// Get the LSQ calc vector (using either only the top or the hierarchy of object)
       const CrystVector_REAL& GetLSQCalc() const;

--- a/ObjCryst/RefinableObj/RefinableObj.cpp
+++ b/ObjCryst/RefinableObj/RefinableObj.cpp
@@ -1655,6 +1655,12 @@ void RefinableObj::AddPar(RefinablePar *newRefPar)
 
 void RefinableObj::AddPar(RefinableObj &newRefParList,const bool copyParam)
 {
+   this->AddPar(newRefParList,copyParam,true);
+}
+
+void RefinableObj::AddPar(RefinableObj &newRefParList,const bool copyParam,
+                          const bool verbose)
+{
    VFN_DEBUG_MESSAGE("RefinableObj::AddPar(RefParList&)" <<newRefParList.GetNbPar() ,2)
    RefinablePar *p;
    for(long i=0;i<newRefParList.GetNbPar();i++)
@@ -1666,9 +1672,10 @@ void RefinableObj::AddPar(RefinableObj &newRefParList,const bool copyParam)
          string name=newRefParList.GetParNameHierarchy(src,2);
          if(this->FindPar(name)!=-1)
          {
-            cerr << "WARNING: RefinableObj::AddPar(..., copyParam=false): "
-                 << "parameter name '" << name << "' is not unique, "
-                 << "appending address suffix." << endl;
+            if(verbose)
+               cerr << "WARNING: RefinableObj::AddPar(..., copyParam=false): "
+                    << "parameter name '" << name << "' is not unique, "
+                    << "appending address suffix." << endl;
             name += ":" + to_string(reinterpret_cast<size_t>(&src));
          }
          p=new RefinableParProxy(src, name);

--- a/ObjCryst/RefinableObj/RefinableObj.h
+++ b/ObjCryst/RefinableObj/RefinableObj.h
@@ -962,6 +962,10 @@ class RefinableObj
       * its name will be automatically appended with an ~
       */
       void AddPar(RefinableObj &newRefParList, const bool copyParam=false);
+      /// Add parameters from another object, optionally warning when hierarchy
+      /// names need an address suffix to remain unique.
+      void AddPar(RefinableObj &newRefParList, const bool copyParam,
+                  const bool verbose);
       /** Remove a refinable parameter.
       *
       * This returns an iterator to the next parameter in the vector.

--- a/test/unit/api_powderpattern.cpp
+++ b/test/unit/api_powderpattern.cpp
@@ -305,6 +305,43 @@ void TestReflectionProfilePseudoVoigt()
       Check(std::isfinite(prof(i)), "PseudoVoigt profile should be finite everywhere");
 }
 
+void TestReflectionProfilePseudoVoigtTCH()
+{
+   using namespace ObjCryst;
+   ReflectionProfilePseudoVoigtTCH profile;
+   Check(!profile.IsAnisotropic(), "TCH pseudo-Voigt should be isotropic");
+
+   const REAL center=30*DEG2RAD;
+   const REAL hg=.08f*DEG2RAD;
+   const REAL hl=.04f*DEG2RAD;
+   profile.SetProfilePar(hg*hg,0,0,0,0,hl);
+   const REAL hg2=hg*hg;
+   const REAL hl2=hl*hl;
+   const REAL h5=hg2*hg2*hg+2.69269f*hg2*hg2*hl
+                 +2.42843f*hg2*hg*hl2+4.47163f*hg2*hl2*hl
+                 +0.07842f*hg*hl2*hl2+hl2*hl2*hl;
+   const REAL expectedFwhm=pow(h5,(REAL).2);
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),expectedFwhm,1e-10,
+                "TCH profile should have the calculated common FWHM");
+
+   CrystVector_REAL x(3);
+   x(0)=center-expectedFwhm/2;
+   x(1)=center;
+   x(2)=center+expectedFwhm/2;
+   const CrystVector_REAL prof=profile.GetProfile(x,center,1,0,0);
+   CheckNearAbs(prof(0)/prof(1),.5,1e-6,
+                "TCH profile should be half-height at -FWHM/2");
+   CheckNearAbs(prof(2)/prof(1),.5,1e-6,
+                "TCH profile should be half-height at +FWHM/2");
+
+   profile.SetProfilePar(hg*hg);
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hg,1e-10,
+                "TCH pure-Gaussian limit should retain H_G");
+   profile.SetProfilePar(0,0,0,0,0,hl);
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hl,1e-10,
+                "TCH pure-Lorentzian limit should retain H_L");
+}
+
 void TestReflectionProfileDoubleExponentialPseudoVoigt()
 {
    using namespace ObjCryst;
@@ -464,6 +501,7 @@ int main(int argc, char* argv[])
    else if(testName == "powderpattern-import") TestPowderPatternImport();
    else if(testName == "scatteringcorr-subclasses") TestScatteringCorrSubclasses();
    else if(testName == "reflectionprofile-pseudo-voigt") TestReflectionProfilePseudoVoigt();
+   else if(testName == "reflectionprofile-pseudo-voigt-tch") TestReflectionProfilePseudoVoigtTCH();
    else if(testName == "reflectionprofile-double-exponential-pv") TestReflectionProfileDoubleExponentialPseudoVoigt();
    else if(testName == "reflectionprofile-pv-anisotropic-direct") TestReflectionProfilePseudoVoigtAnisotropicDirect();
    else if(testName == "powder-groundtruth-xray-pv-gaussian") TestPowderGroundTruthXrayPseudoVoigtGaussian();

--- a/test/unit/api_powderpattern.cpp
+++ b/test/unit/api_powderpattern.cpp
@@ -321,7 +321,7 @@ void TestReflectionProfilePseudoVoigtTCH()
                  +2.42843f*hg2*hg*hl2+4.47163f*hg2*hl2*hl
                  +0.07842f*hg*hl2*hl2+hl2*hl2*hl;
    const REAL expectedFwhm=pow(h5,(REAL).2);
-   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),expectedFwhm,1e-10,
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),expectedFwhm,1e-9,
                 "TCH profile should have the calculated common FWHM");
 
    CrystVector_REAL x(3);
@@ -329,16 +329,16 @@ void TestReflectionProfilePseudoVoigtTCH()
    x(1)=center;
    x(2)=center+expectedFwhm/2;
    const CrystVector_REAL prof=profile.GetProfile(x,center,1,0,0);
-   CheckNearAbs(prof(0)/prof(1),.5,1e-6,
+   CheckNearAbs(prof(0)/prof(1),.5,2e-5,
                 "TCH profile should be half-height at -FWHM/2");
-   CheckNearAbs(prof(2)/prof(1),.5,1e-6,
+   CheckNearAbs(prof(2)/prof(1),.5,2e-5,
                 "TCH profile should be half-height at +FWHM/2");
 
    profile.SetProfilePar(hg*hg);
-   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hg,1e-10,
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hg,1e-9,
                 "TCH pure-Gaussian limit should retain H_G");
    profile.SetProfilePar(0,0,0,0,0,hl);
-   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hl,1e-10,
+   CheckNearAbs(profile.GetFullProfileWidth(.5,center,1,0,0),hl,1e-9,
                 "TCH pure-Lorentzian limit should retain H_L");
 }
 

--- a/test/unit/run_unit_tests.sh
+++ b/test/unit/run_unit_tests.sh
@@ -81,6 +81,7 @@ run_test "unit::powderpattern-diffraction-lebail-fhklobs" "$SCRIPT_DIR/api_powde
 run_test "unit::powderpattern-import" "$SCRIPT_DIR/api_powderpattern" "powderpattern-import"
 run_test "unit::scatteringcorr-subclasses" "$SCRIPT_DIR/api_powderpattern" "scatteringcorr-subclasses"
 run_test "unit::reflectionprofile-pseudo-voigt" "$SCRIPT_DIR/api_powderpattern" "reflectionprofile-pseudo-voigt"
+run_test "unit::reflectionprofile-pseudo-voigt-tch" "$SCRIPT_DIR/api_powderpattern" "reflectionprofile-pseudo-voigt-tch"
 run_test "unit::reflectionprofile-double-exponential-pv" "$SCRIPT_DIR/api_powderpattern" "reflectionprofile-double-exponential-pv"
 run_test "unit::powder-groundtruth-xray-pv-gaussian" "$SCRIPT_DIR/api_powderpattern" "powder-groundtruth-xray-pv-gaussian"
 run_test "unit::powder-groundtruth-xray-pv-lorentzian" "$SCRIPT_DIR/api_powderpattern" "powder-groundtruth-xray-pv-lorentzian"


### PR DESCRIPTION
It's pretty close to the GSAS-II parameterization. It has instrument parameters U,V,W for Gaussian and X,Y,Z for Lorentzian shape. They are combined into effective PV mixing with the Thompson-Cox-Hastings approximation. 

Peak broadening is handled like GSAS-II: Scherrer P parameter, broadening ∝1/cos(θ), and acts on Gaussian and Lorentzian FWHM based on LGmix parameter (by default 1 i.e. purely Lorentzian).

`ReflectionProfilePseudoVoigtTCH` is different from `ReflectionProfilePseudoVoigtAnisotropic` in that it's isotropic, has a Z for constant Lorentz width, handles P peak broadening differently, and doesn't use an explicit mixing parameter Eta. 
So it's "less empirical" in some respects than `ReflectionProfilePseudoVoigt(Anisotropic)`.

Plus, it's new, so we could extend it without breaking old code. 
So far it doesn't have microstrain or reciprocal unit cell deformation with tensor Dij. 